### PR TITLE
Correctly load coremod when in the decompiled environment (running from an IDE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 ForgeHax.iml
-build/*
-run/*
-.idea/*
-.gradle/*
-storage_test/*
+build/
+run/
+classes/
+.idea/
+.gradle/
+storage_test/
 libs/journeymap*
+gradle/
+gradlew
+gradlew.bat

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ A Minecraft cheat that runs as a Forge mod
 
 If you want to build the project on your own, you need to either remove all references to JourneyMap or add the latest JourneyMap release into the libs/ folder
 
-To load the core mod in the IDE add this to the VM options: 
--Dfml.coreMods.load=com.matt.forgehax.asm.ForgeHaxCoreMod
+You should allocate more ram when running `setupDecompWorkspace` (around 4GB should be ok)
 
 I recommend allocating more ram in both environments as the BlockEsp mod requires a lot of space for the vertex buffers. I might get around to fixing this if it becomes too big of an issue.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ForgeHax
 A Minecraft cheat that runs as a Forge mod
 
-If you want to build the project on your own, you need to either remove all references to JourneyMap or add the latest JourneyMap release into the libs/ folder
+If you want to build the project on your own, you need to either remove all references to JourneyMap or add the latest [JourneyMap](http://journeymap.info/Download) release into the libs/ folder
 
 You should allocate more ram when running `setupDecompWorkspace` (around 4GB should be ok)
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,11 @@ dependencies {
 
 jar {
     manifest {
-        attributes 'FMLCorePlugin': 'com.matt.forgehax.asm.ForgeHaxCoreMod',
+        attributes (
+                'FMLCorePlugin': 'com.matt.forgehax.asm.ForgeHaxCoreMod',
                 'FMLCorePluginContainsFMLMod': 'true',
                 'FMLAT': 'forgehax_at.cfg'
+        )
         /*
         attributes 'FMLCorePlugin': 'com.matt.forgehax.asm2.CoreMod',
                 'FMLCorePluginContainsFMLMod': 'true'*/

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+FMLCorePlugin: com.matt.forgehax.asm.ForgeHaxCoreMod,
+FMLCorePluginContainsFMLMod: true,
+FMLAT: forgehax_at.cfg


### PR DESCRIPTION
Ensure that the manifest exists when running from an IDE. See commit messages.

Also updated `.gitignore` and `README.md`