### PR TITLE
BookBot: Add warning for book names longer than 32

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/BookBot.java
+++ b/src/main/java/com/matt/forgehax/mods/BookBot.java
@@ -46,6 +46,16 @@ public class BookBot extends ToggleMod {
           .name("name")
           .description("Name of the book, use {NUMBER} for the number")
           .defaultTo("Book #{NUMBER}")
+          .processor(
+              data -> {
+                String bname = data.getArgument(0);
+
+                if (bname != null && bname.length() > 32) {
+                  Helper.printWarning(
+                      "Final book names longer than 32 letters will cause crashes! Current length: %d",
+                      bname.length());
+                }
+              })
           .build();
 
   private final Setting<String> file =
@@ -249,7 +259,7 @@ public class BookBot extends ToggleMod {
         .processor(
             data -> {
               writer = loadFile();
-              data.write(String.format("BookBot file \"%s\"loaded successfully", file.get()));
+              data.write(String.format("BookBot file \"%s\" loaded successfully", file.get()));
             })
         .build();
 


### PR DESCRIPTION
Server kicks you when you try to write book with titles >32 chars. Normal Minecraft limit is far below that anyway, ~17 or so.

I thought a warning message is enough, otherwise there're placeholders to handle.

Feel free to discard if you got a better solution.
```
[00:08:44] [main/FATAL]: Error executing task
java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: Payload may not be larger than 32767 bytes
	at java.util.concurrent.FutureTask.report(Unknown Source) ~[?:1.8.0_161]
	at java.util.concurrent.FutureTask.get(Unknown Source) ~[?:1.8.0_161]
	at net.minecraft.util.Util.func_181617_a(SourceFile:47) [h.class:?]
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1086) [bib.class:?]
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:397) [bib.class:?]
	at net.minecraft.client.main.Main.main(SourceFile:123) [Main.class:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_161]
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_161]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:1.8.0_161]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:1.8.0_161]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) [launchwrapper-1.12.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28) [launchwrapper-1.12.jar:?]
Caused by: java.lang.IllegalArgumentException: Payload may not be larger than 32767 bytes
	at net.minecraft.network.play.client.CPacketCustomPayload.<init>(CPacketCustomPayload.java:28) ~[lh.class:?]
	at com.matt.forgehax.mods.BookBot$BookWriter.sendBook(BookBot.java:402) ~[BookBot$BookWriter.class:?]
	at com.matt.forgehax.mods.BookBot$BookWriter.lambda$run$1(BookBot.java:463) ~[BookBot$BookWriter.class:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[?:1.8.0_161]
	at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:1.8.0_161]
	at net.minecraft.util.Util.func_181617_a(SourceFile:46) ~[h.class:?]
	... 9 more
```