### PR TITLE
@Nullable getNetworkManager()

### DIFF
--- a/src/main/java/com/matt/forgehax/Helper.java
+++ b/src/main/java/com/matt/forgehax/Helper.java
@@ -76,7 +76,8 @@ public class Helper implements Globals {
   public static World getWorld(TileEntity tileEntity) {
     return tileEntity.getWorld();
   }
-
+  
+  @Nullable
   public static NetworkManager getNetworkManager() {
     return FMLClientHandler.instance().getClientToServerNetworkManager();
   }


### PR DESCRIPTION
If packet event is fired by InstantMessage other event receivers will not have a ready NetworkManager at that stage. So `FMLClientHandler.instance().getClientToServerNetworkManager()` might return null

https://github.com/fr1kin/ForgeHax/blob/master/src/main/java/com/matt/forgehax/mods/InstantMessage.java#L35