### PR TITLE
Update FPSLock and Fullbright

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/FPSLock.java
+++ b/src/main/java/com/matt/forgehax/mods/FPSLock.java
@@ -12,7 +12,18 @@ import org.lwjgl.opengl.Display;
 
 @RegisterMod
 public class FPSLock extends ToggleMod {
-  private final Setting<Integer> fps =
+
+    private final Setting<Integer> defaultFps =
+      getCommandStub()
+          .builders()
+          .<Integer>newSettingBuilder()
+          .name("default-fps")
+          .description("default FPS to revert to")
+          .defaultTo(MC.gameSettings.limitFramerate)
+          .min(1)
+          .build();
+
+    private final Setting<Integer> fps =
       getCommandStub()
           .builders()
           .<Integer>newSettingBuilder()
@@ -38,7 +49,7 @@ public class FPSLock extends ToggleMod {
           .name("no-focus-fps")
           .description("FPS when the game window doesn't have focus. Set to 0 to disable.")
           .min(0)
-          .defaultTo(1)
+          .defaultTo(3)
           .build();
 
   public FPSLock() {
@@ -51,13 +62,13 @@ public class FPSLock extends ToggleMod {
 
   private int getFps() {
     if (no_focus_fps.get() > 0 && !Display.isActive()) return no_focus_fps.get();
-    else if (getWorld() != null) return fps.get() > 0 ? fps.get() : MC.gameSettings.limitFramerate;
-    else return menu_fps.get() > 0 ? menu_fps.get() : MC.gameSettings.limitFramerate;
+    else if (MC.currentScreen != null) return menu_fps.get() > 0 ? menu_fps.get() : defaultFps.get();
+    else return fps.get() > 0 ? fps.get() : defaultFps.get();
   }
 
   @Override
   protected void onDisabled() {
-    MC.gameSettings.limitFramerate = 60;
+    MC.gameSettings.limitFramerate = defaultFps.get();
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/FullBrightMod.java
+++ b/src/main/java/com/matt/forgehax/mods/FullBrightMod.java
@@ -1,5 +1,6 @@
 package com.matt.forgehax.mods;
 
+import com.matt.forgehax.util.command.Setting;
 import com.matt.forgehax.util.mod.Category;
 import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
@@ -12,6 +13,17 @@ public class FullBrightMod extends ToggleMod {
     super(Category.WORLD, "FullBright", false, "Makes everything render with maximum brightness");
   }
 
+  private final Setting<Float> defaultGamma =
+      getCommandStub()
+      .builders()
+      .<Float>newSettingBuilder()
+      .name("gamma")
+      .description("default gamma to revert to")
+      .defaultTo(MC.gameSettings.gammaSetting)
+      .min(0.1F)
+      .max(16F)
+      .build();
+
   @Override
   public void onEnabled() {
     MC.gameSettings.gammaSetting = 16F;
@@ -19,7 +31,7 @@ public class FullBrightMod extends ToggleMod {
 
   @Override
   public void onDisabled() {
-    MC.gameSettings.gammaSetting = 1F;
+    MC.gameSettings.gammaSetting = defaultGamma.get();
   }
 
   @SubscribeEvent


### PR DESCRIPTION
 with support for default value, FPSLock fix

FPSLock didn't really recognise any gui/menu

Added default values, to completely replaces Minecraft Settings since they're what we modify (as I didn't find out a way to reliably save pre-mod settings on shutdown)

no-focus-fps 3 allows fps to rise faster to normal levels