### PR TITLE
Run docker image as jenkins user

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,7 +2,7 @@ version: '2.3'
 services:
     forgehax:
         image: gradle:4.10.0-jdk8-slim
-        user: root
+        user: "1002:1002"
         environment:
           - GIT_COMMIT=${GIT_COMMIT:-latest}
           - FORGEHAX_DEBUG=1

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,6 +23,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else    
+        mkdir -p .gradle
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f docker-compose.ci.yml \
             run --rm \

--- a/scripts/update
+++ b/scripts/update
@@ -17,6 +17,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else        
+        mkdir -p .gradle
         docker-compose \
             -f docker-compose.ci.yml \
             run --rm \


### PR DESCRIPTION
The current ci config has gradle running as root which creates a problem where jenkins cannot clear the workspace because the gradle cache is owned by root.