### PR TITLE
QoL changes

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/ActiveModList.java
+++ b/src/main/java/com/matt/forgehax/mods/ActiveModList.java
@@ -12,6 +12,7 @@ import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
+import net.minecraft.client.gui.GuiChat;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -123,18 +124,30 @@ public class ActiveModList extends ToggleMod {
       SurfaceHelper.drawTextShadow(generateTickRateText(), posX, posY.get(), Utils.Colors.WHITE);
       posY.addAndGet(SurfaceHelper.getTextHeight() + 1);
     }
-    getModManager()
-        .getMods()
-        .stream()
-        .filter(BaseMod::isEnabled)
-        .filter(mod -> !mod.isHidden())
-        .map(mod -> debug.get() ? mod.getDebugDisplayText() : mod.getDisplayText())
-        .sorted(sortMode.get().getComparator())
-        .forEach(
-            name -> {
-              SurfaceHelper.drawTextShadow(">" + name, posX, posY.get(), Utils.Colors.WHITE);
-              posY.addAndGet(SurfaceHelper.getTextHeight() + 1);
-            });
+
+    if (MC.currentScreen instanceof GuiChat || MC.gameSettings.showDebugInfo) {
+      long enabledMods = getModManager()
+          .getMods()
+          .stream()
+          .filter(BaseMod::isEnabled)
+          .filter(mod -> !mod.isHidden())
+          .count();
+      SurfaceHelper.drawTextShadow(enabledMods + " mods enabled",
+          posX, posY.get(), Utils.Colors.WHITE);
+    } else {
+      getModManager()
+          .getMods()
+          .stream()
+          .filter(BaseMod::isEnabled)
+          .filter(mod -> !mod.isHidden())
+          .map(mod -> debug.get() ? mod.getDebugDisplayText() : mod.getDisplayText())
+          .sorted(sortMode.get().getComparator())
+          .forEach(
+              name -> {
+                SurfaceHelper.drawTextShadow(">" + name, posX, posY.get(), Utils.Colors.WHITE);
+                posY.addAndGet(SurfaceHelper.getTextHeight() + 1);
+              });
+    }
     /*
     posY += (Render2DUtils.getTextHeight() + 1) * 2;
     Render2DUtils.drawTextShadow(String.format("Pitch: %.4f", MC.thePlayer.rotationPitch), posX, posY, Utils.toRGBA(255, 255, 255, 255));

--- a/src/main/java/com/matt/forgehax/mods/AutoRespawnMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoRespawnMod.java
@@ -2,11 +2,17 @@ package com.matt.forgehax.mods;
 
 import static com.matt.forgehax.Helper.getLocalPlayer;
 
+import com.matt.forgehax.Helper;
 import com.matt.forgehax.events.LocalPlayerUpdateEvent;
+import com.matt.forgehax.util.command.Setting;
 import com.matt.forgehax.util.mod.Category;
 import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
+
 
 @RegisterMod
 public class AutoRespawnMod extends ToggleMod {
@@ -14,10 +20,43 @@ public class AutoRespawnMod extends ToggleMod {
     super(Category.PLAYER, "AutoRespawn", false, "Auto respawn on death");
   }
 
+  private final Setting<Integer> delay =
+      getCommandStub()
+        .builders()
+        .<Integer>newSettingBuilder()
+        .name("delay")
+        .description("wait ticks before respawning")
+        .min(0)
+        .defaultTo(50)
+        .build();
+
+  private boolean isDead = false;
+  private long deadTicks = 0;
+
+  @SubscribeEvent
+  public void onClientTick(ClientTickEvent ev) {
+    if (isDead) {
+      deadTicks++;
+      if (deadTicks > delay.getAsInteger()) {
+        deadTicks = 0;
+        isDead = false;
+        getLocalPlayer().respawnPlayer();
+      }
+    }
+  }
+
   @SubscribeEvent
   public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
     if (getLocalPlayer().getHealth() <= 0) {
-      getLocalPlayer().respawnPlayer();
+      if (isDead == false) { // print once
+        Helper.printInform("Died at %.1f, %.1f, %.1f on %s",
+            getLocalPlayer().posX,
+            getLocalPlayer().posY,
+            getLocalPlayer().posZ,
+            new SimpleDateFormat("HH:mm:ss").format(new Date())
+        );
+      }
+      isDead = true;
     }
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/AutoRespawnMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoRespawnMod.java
@@ -31,7 +31,7 @@ public class AutoRespawnMod extends ToggleMod {
         .build();
 
   private boolean isDead = false;
-  private long deadTicks = 0;
+  private int deadTicks = 0;
 
   @SubscribeEvent
   public void onClientTick(ClientTickEvent ev) {

--- a/src/main/java/com/matt/forgehax/mods/HorseStats.java
+++ b/src/main/java/com/matt/forgehax/mods/HorseStats.java
@@ -1,5 +1,6 @@
 package com.matt.forgehax.mods;
 
+import static com.matt.forgehax.Helper.getLocalPlayer;
 import static com.matt.forgehax.Helper.getRidingEntity;
 
 import com.matt.forgehax.asm.reflection.FastReflection;
@@ -21,7 +22,7 @@ public class HorseStats extends ToggleMod {
     super(Category.PLAYER, "HorseStats", false, "Change the stats of your horse");
   }
 
-  public final Setting<Double> jumpHeight =
+  private final Setting<Double> jumpHeight =
       getCommandStub()
           .builders()
           .<Double>newSettingBuilder()
@@ -29,7 +30,7 @@ public class HorseStats extends ToggleMod {
           .description("Modified horse jump height attribute. Default: 1")
           .defaultTo(1.0D)
           .build();
-  public final Setting<Double> speed =
+  private final Setting<Double> speed =
       getCommandStub()
           .builders()
           .<Double>newSettingBuilder()
@@ -38,22 +39,46 @@ public class HorseStats extends ToggleMod {
           .defaultTo(0.3375D)
           .build();
 
+  private final Setting<Double> multiplier =
+      getCommandStub()
+        .builders()
+        .<Double>newSettingBuilder()
+        .name("multiplier")
+        .description("multiplier while sprinting")
+        .defaultTo(1.0D)
+        .build();
+
+  @Override
+  public void onDisabled() {
+    if (getRidingEntity() != null && getRidingEntity() instanceof AbstractHorse) {
+      applyStats(jumpHeight.getDefault(), speed.getDefault());
+    }
+  }
+
   @SubscribeEvent
   public void onLivingUpdate(LivingEvent.LivingUpdateEvent event) {
     if (EntityUtils.isDrivenByPlayer(event.getEntity())
         && getRidingEntity() instanceof AbstractHorse) {
 
-      final IAttribute jump_strength =
-          FastReflection.Fields.AbstractHorse_JUMP_STRENGTH.get(getRidingEntity());
-      final IAttribute movement_speed =
-          FastReflection.Fields.SharedMonsterAttributes_MOVEMENT_SPEED.get(getRidingEntity());
-
-      ((EntityLivingBase) getRidingEntity())
-          .getEntityAttribute(jump_strength)
-          .setBaseValue(jumpHeight.getAsDouble());
-      ((EntityLivingBase) getRidingEntity())
-          .getEntityAttribute(movement_speed)
-          .setBaseValue(speed.getAsDouble());
+      double newSpeed = speed.getAsDouble();
+      if (getLocalPlayer().isSprinting()) {
+        newSpeed *= multiplier.getAsDouble();
+      }
+      applyStats(jumpHeight.getAsDouble(), newSpeed);
     }
+  }
+
+  private void applyStats(double newJump, double newSpeed) {
+    final IAttribute jump_strength =
+        FastReflection.Fields.AbstractHorse_JUMP_STRENGTH.get(getRidingEntity());
+    final IAttribute movement_speed =
+        FastReflection.Fields.SharedMonsterAttributes_MOVEMENT_SPEED.get(getRidingEntity());
+
+    ((EntityLivingBase) getRidingEntity())
+        .getEntityAttribute(jump_strength)
+        .setBaseValue(newJump);
+    ((EntityLivingBase) getRidingEntity())
+        .getEntityAttribute(movement_speed)
+        .setBaseValue(newSpeed);
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/HorseStats.java
+++ b/src/main/java/com/matt/forgehax/mods/HorseStats.java
@@ -50,7 +50,7 @@ public class HorseStats extends ToggleMod {
 
   @Override
   public void onDisabled() {
-    if (getRidingEntity() != null && getRidingEntity() instanceof AbstractHorse) {
+    if (getRidingEntity() instanceof AbstractHorse) {
       applyStats(jumpHeight.getDefault(), speed.getDefault());
     }
   }


### PR DESCRIPTION
AutoRes: JourneyMap needs a ~40 tick delay for some reason to save the death coord. The default delay set to 50.

Horsestats: Added multiplier for sprinting, so you can make it a 'boost' for ocean/highway riding. onDisable resets your horse's stats thats slightly better than nothing at all imo

Activemods: less clutter