### PR TITLE
Add .say (-f) command

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/commands/SayCommand.java
+++ b/src/main/java/com/matt/forgehax/mods/commands/SayCommand.java
@@ -1,0 +1,45 @@
+package com.matt.forgehax.mods.commands;
+
+import static com.matt.forgehax.Helper.getLocalPlayer;
+
+import com.matt.forgehax.util.command.Command;
+import com.matt.forgehax.util.command.CommandBuilders;
+import com.matt.forgehax.util.mod.CommandMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import java.util.Arrays;
+
+@RegisterMod
+public class SayCommand extends CommandMod {
+    public SayCommand() { super("SayCommand"); }
+
+    @RegisterCommand
+    public Command say(CommandBuilders builders) {
+        return builders
+            .newCommandBuilder()
+            .name("say")
+            .description("Send chat message")
+            .options(
+                parser -> {
+                    parser.acceptsAll(Arrays.asList("fake", "f"), "Send a fake message that won't be treated as command");
+                }
+            )
+            .processor(
+                data -> {
+                    boolean fake = data.hasOption("fake");
+                    // any emoji will work until 1.13
+                    final int fakePrefix = 0x1F921;
+                    final String msg = data.getArgumentCount() > 0 ? data.getArgumentAsString(0) : "";
+                    if (getLocalPlayer() != null) {
+                        if (fake) {
+                            getLocalPlayer().sendChatMessage(
+                                new StringBuilder().appendCodePoint(fakePrefix).append(msg).toString()
+                            );
+                        } else {
+                            getLocalPlayer().sendChatMessage(msg);
+                        }
+                    }
+                }
+            )
+            .build();
+    }
+}

--- a/src/main/java/com/matt/forgehax/mods/commands/SayCommand.java
+++ b/src/main/java/com/matt/forgehax/mods/commands/SayCommand.java
@@ -2,11 +2,13 @@ package com.matt.forgehax.mods.commands;
 
 import static com.matt.forgehax.Helper.getLocalPlayer;
 
+import com.matt.forgehax.util.PacketHelper;
 import com.matt.forgehax.util.command.Command;
 import com.matt.forgehax.util.command.CommandBuilders;
 import com.matt.forgehax.util.mod.CommandMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
 import java.util.Arrays;
+import net.minecraft.network.play.client.CPacketChatMessage;
 
 @RegisterMod
 public class SayCommand extends CommandMod {
@@ -28,15 +30,13 @@ public class SayCommand extends CommandMod {
                     boolean fake = data.hasOption("fake");
                     // any emoji will work until 1.13
                     final int fakePrefix = 0x1F921;
-                    final String msg = data.getArgumentCount() > 0 ? data.getArgumentAsString(0) : "";
+                    String msg = data.getArgumentCount() > 0 ? data.getArgumentAsString(0) : "";
+
                     if (getLocalPlayer() != null) {
                         if (fake) {
-                            getLocalPlayer().sendChatMessage(
-                                new StringBuilder().appendCodePoint(fakePrefix).append(msg).toString()
-                            );
-                        } else {
-                            getLocalPlayer().sendChatMessage(msg);
+                            msg = new StringBuilder().appendCodePoint(fakePrefix).append(msg).toString();
                         }
+                        PacketHelper.ignoreAndSend(new CPacketChatMessage(msg));
                     }
                 }
             )

--- a/src/main/java/com/matt/forgehax/mods/services/ChatCommandService.java
+++ b/src/main/java/com/matt/forgehax/mods/services/ChatCommandService.java
@@ -2,6 +2,7 @@ package com.matt.forgehax.mods.services;
 
 import com.matt.forgehax.Helper;
 import com.matt.forgehax.asm.events.PacketEvent;
+import com.matt.forgehax.util.PacketHelper;
 import com.matt.forgehax.util.command.CommandHelper;
 import com.matt.forgehax.util.command.Setting;
 import com.matt.forgehax.util.command.exception.CommandExecuteException;
@@ -43,7 +44,8 @@ public class ChatCommandService extends ServiceMod {
   public void onSendPacket(PacketEvent.Outgoing.Pre event) {
     if (event.getPacket() instanceof CPacketChatMessage) {
       String message = ((CPacketChatMessage) event.getPacket()).getMessage();
-      if (message.startsWith(activationCharacter.getAsString()) && message.length() > 1) {
+      if (!PacketHelper.isIgnored(event.getPacket())
+          && message.startsWith(activationCharacter.getAsString()) && message.length() > 1) {
         // cut out the . from the message
         String line = message.substring(1);
         handleCommand(line);

--- a/src/main/java/com/matt/forgehax/util/command/Command.java
+++ b/src/main/java/com/matt/forgehax/util/command/Command.java
@@ -5,7 +5,6 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.matt.forgehax.Globals;
 import com.matt.forgehax.Helper;
-import com.matt.forgehax.mods.services.ChatCommandService;
 import com.matt.forgehax.util.SafeConverter;
 import com.matt.forgehax.util.command.callbacks.CallbackData;
 import com.matt.forgehax.util.command.exception.CommandBuildException;
@@ -242,9 +241,8 @@ public class Command implements Comparable<Command>, ISerializer, GsonConstant {
 
   protected boolean processChildren(@Nonnull String[] args)
       throws CommandExecuteException, NullPointerException {
-    if (args.length > 0
-        && !args[0].startsWith(ChatCommandService.getActivationCharacter().toString())) {
-      final String lookup = args[0].toLowerCase();
+    if (args.length > 0) {
+      final String lookup = (args[0] != null ? args[0] : Strings.EMPTY).toLowerCase();
       Command child = getChild(lookup);
       if (child != null) { // perfect match, use this
         child.run(CommandHelper.forward(args));

--- a/src/main/java/com/matt/forgehax/util/command/Command.java
+++ b/src/main/java/com/matt/forgehax/util/command/Command.java
@@ -5,6 +5,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.matt.forgehax.Globals;
 import com.matt.forgehax.Helper;
+import com.matt.forgehax.mods.services.ChatCommandService;
 import com.matt.forgehax.util.SafeConverter;
 import com.matt.forgehax.util.command.callbacks.CallbackData;
 import com.matt.forgehax.util.command.exception.CommandBuildException;
@@ -241,8 +242,9 @@ public class Command implements Comparable<Command>, ISerializer, GsonConstant {
 
   protected boolean processChildren(@Nonnull String[] args)
       throws CommandExecuteException, NullPointerException {
-    if (args.length > 0) {
-      final String lookup = (args[0] != null ? args[0] : Strings.EMPTY).toLowerCase();
+    if (args.length > 0
+        && !args[0].startsWith(ChatCommandService.getActivationCharacter().toString())) {
+      final String lookup = args[0].toLowerCase();
       Command child = getChild(lookup);
       if (child != null) { // perfect match, use this
         child.run(CommandHelper.forward(args));


### PR DESCRIPTION
& Stop evaluating child arguments starting with cmdprefix: prevents evaluating the second word in `.say .say`

If you want to merge this PR, `.say -f "/kill yes"`
oh and /kill was disabled!