### PR TITLE
Chatbot: Add option to reset sequential index on disable

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/ChatBot.java
+++ b/src/main/java/com/matt/forgehax/mods/ChatBot.java
@@ -33,7 +33,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @RegisterMod
 public class ChatBot extends ToggleMod {
-  public final Options<SpamEntry> spams =
+  private final Options<SpamEntry> spams =
       getCommandStub()
           .builders()
           .<SpamEntry>newOptionsBuilder()
@@ -43,7 +43,7 @@ public class ChatBot extends ToggleMod {
           .supplier(Sets::newConcurrentHashSet)
           .build();
 
-  public final Setting<Integer> max_input_length =
+  private final Setting<Integer> max_input_length =
       getCommandStub()
           .builders()
           .<Integer>newSettingBuilder()
@@ -54,8 +54,26 @@ public class ChatBot extends ToggleMod {
           .max(256)
           .build();
 
+  private final Setting<Boolean> resetSequentialIndex =
+    getCommandStub()
+    .builders()
+    .<Boolean>newSettingBuilder()
+    .name("resetSequential")
+    .description("resets spam line counter for Sequential mode")
+    .defaultTo(false)
+    .build();
+
   public ChatBot() {
     super(Category.MISC, "ChatBot", false, "Spam chat");
+  }
+
+  @Override
+  protected void onDisabled() {
+    if (resetSequentialIndex.get()) {
+      for (SpamEntry e : spams) {
+        e.reset();
+      }
+    }
   }
 
   @Override
@@ -103,6 +121,7 @@ public class ChatBot extends ToggleMod {
               if (data.hasOption("trigger")) entry.setTrigger(data.getOptionAsString("trigger"));
               if (data.hasOption("enabled"))
                 entry.setEnabled(SafeConverter.toBoolean(data.getOptionAsString("enabled")));
+                if (!entry.isEnabled() && resetSequentialIndex.get()) entry.reset();
               if (data.hasOption("delay"))
                 entry.setDelay(SafeConverter.toLong(data.getOptionAsString("delay")));
 

--- a/src/main/java/com/matt/forgehax/mods/ChatBot.java
+++ b/src/main/java/com/matt/forgehax/mods/ChatBot.java
@@ -58,8 +58,8 @@ public class ChatBot extends ToggleMod {
     getCommandStub()
     .builders()
     .<Boolean>newSettingBuilder()
-    .name("resetSequential")
-    .description("resets spam line counter for Sequential mode")
+    .name("reset-sequential")
+    .description("start spam list anew in sequential mode")
     .defaultTo(false)
     .build();
 


### PR DESCRIPTION
Add an option to reset Sequential mode's counter when Chatbot is disabled or the specific spam list is disabled

Old behaviour (false):

- one
- [disabled], [enabled]
- two
- three

New behaviour (when set to true)

- one
- [disabled], [enabled]
- one
- two