### PR TITLE
.say & .clear addition

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/commands/HelpCommand.java
+++ b/src/main/java/com/matt/forgehax/mods/commands/HelpCommand.java
@@ -227,8 +227,9 @@ public class HelpCommand extends CommandMod {
         .newCommandBuilder()
         .name("clear")
         .description("Clears chat")
+        .options(p -> p.acceptsAll(Arrays.asList("all", "a"), "Also clear sent message history"))
         .processor(d -> MC.addScheduledTask(
-          () -> MC.ingameGUI.getChatGUI().clearChatMessages(true))
+          () -> MC.ingameGUI.getChatGUI().clearChatMessages(d.hasOption("all")))
         )
         .build();
     }

--- a/src/main/java/com/matt/forgehax/mods/commands/SayCommand.java
+++ b/src/main/java/com/matt/forgehax/mods/commands/SayCommand.java
@@ -23,6 +23,7 @@ public class SayCommand extends CommandMod {
             .options(
                 parser -> {
                     parser.acceptsAll(Arrays.asList("fake", "f"), "Send a fake message that won't be treated as command");
+                    parser.acceptsAll(Arrays.asList("local", "l"), "Send message from local chat");
                 }
             )
             .processor(
@@ -36,7 +37,11 @@ public class SayCommand extends CommandMod {
                         if (fake) {
                             msg = new StringBuilder().appendCodePoint(fakePrefix).append(msg).toString();
                         }
-                        PacketHelper.ignoreAndSend(new CPacketChatMessage(msg));
+                        if (data.hasOption("local")) {
+                          getLocalPlayer().sendChatMessage(msg);
+                        } else {
+                          PacketHelper.ignoreAndSend(new CPacketChatMessage(msg));
+                        }
                     }
                 }
             )


### PR DESCRIPTION
.clear also cleared sent messages, lets not do this by default

`.say --local` now sends messages via `localPlayer.sendChatMessage()` so it can be used as a hack for macros to control other mods and baritone for more epic **BaritoneCompatibility** leijurv would be proud:

`.bindmacro f6 "spamservice reset;chatbot en 1;say -l #stop"` 