### PR TITLE
Add unstep, fixes #114

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -94,8 +94,6 @@ public class StepMod extends ToggleMod {
 
   @SubscribeEvent
   public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
-    if (!MC.isCallingFromMinecraftThread()) return;
-
     EntityPlayer player = (EntityPlayer) event.getEntityLiving();
     if (player == null) return;
 

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -84,9 +84,9 @@ public class StepMod extends ToggleMod {
     if (!player.world.collidesWithAnyBlock(range)) return;
 
     List<AxisAlignedBB> collisionBoxes = player.world.getCollisionBoxes(player, range);
-    AtomicReference<Double> _newY = new AtomicReference<>(0D);
-    collisionBoxes.forEach(box -> _newY.set(Math.max(_newY.get(), box.maxY)));
-    player.setPositionAndUpdate(player.posX, _newY.get(), player.posZ);
+    AtomicReference<Double> newY = new AtomicReference<>(0D);
+    collisionBoxes.forEach(box -> newY.set(Math.max(newY.get(), box.maxY)));
+    player.setPositionAndUpdate(player.posX, newY.get(), player.posZ);
   }
 
   public void updateUnstep(EntityPlayer player) {

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -33,7 +33,8 @@ public class StepMod extends ToggleMod {
           .defaultTo(1.2f)
           .min(0f)
           .success(__ -> {
-            updateStepHeight(getLocalPlayer());
+            EntityPlayer player = getLocalPlayer();
+            if (player != null) updateStepHeight(player);
           })
           .build();
 
@@ -51,10 +52,15 @@ public class StepMod extends ToggleMod {
   }
 
   @Override
+  protected void onEnabled() {
+    EntityPlayer player = getLocalPlayer();
+    if (player != null) wasOnGround = player.onGround;
+  }
+
+  @Override
   public void onDisabled() {
-    if (getLocalPlayer() != null) {
-      getLocalPlayer().stepHeight = DEFAULT_STEP_HEIGHT;
-    }
+    EntityPlayer player = getLocalPlayer();
+    if (player != null) player.stepHeight = DEFAULT_STEP_HEIGHT;
   }
 
   void updateStepHeight(EntityPlayer player) {
@@ -65,7 +71,7 @@ public class StepMod extends ToggleMod {
     }
   }
 
-  public boolean wasOnGround = true;
+  public boolean wasOnGround = false;
 
   public void unstep(EntityPlayer player) {
     if (!MC.isCallingFromMinecraftThread())
@@ -95,6 +101,7 @@ public class StepMod extends ToggleMod {
   @SubscribeEvent
   public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
     EntityPlayer player = (EntityPlayer) event.getEntityLiving();
+    if (player == null) return;
 
     updateStepHeight(player);
     updateUnstep(player);

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -33,8 +33,10 @@ public class StepMod extends ToggleMod {
           .defaultTo(1.2f)
           .min(0f)
           .success(__ -> {
-            EntityPlayer player = getLocalPlayer();
-            if (player != null) updateStepHeight(player);
+            if (isEnabled()) {
+              EntityPlayer player = getLocalPlayer();
+              if (player != null) updateStepHeight(player);
+            }
           })
           .build();
 

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -94,10 +94,7 @@ public class StepMod extends ToggleMod {
 
   @SubscribeEvent
   public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
-    if (!MC.isCallingFromMinecraftThread()) {
-      MC.addScheduledTask(() -> onLocalPlayerUpdate(event));
-      return;
-    }
+    if (!MC.isCallingFromMinecraftThread()) return;
 
     EntityPlayer player = (EntityPlayer) event.getEntityLiving();
     if (player == null) return;

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -86,8 +86,7 @@ public class StepMod extends ToggleMod {
     List<AxisAlignedBB> collisionBoxes = player.world.getCollisionBoxes(player, range);
     AtomicReference<Double> _newY = new AtomicReference<>(0D);
     collisionBoxes.forEach(box -> _newY.set(Math.max(_newY.get(), box.maxY)));
-    double newY = _newY.get();
-    player.setPositionAndUpdate(player.posX, newY, player.posZ);
+    player.setPositionAndUpdate(player.posX, _newY.get(), player.posZ);
   }
 
   public void updateUnstep(EntityPlayer player) {

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -33,10 +33,12 @@ public class StepMod extends ToggleMod {
           .defaultTo(1.2f)
           .min(0f)
           .success(__ -> {
-            if (isEnabled()) {
-              EntityPlayer player = getLocalPlayer();
-              if (player != null) updateStepHeight(player);
-            }
+            MC.addScheduledTask(() -> {
+              if (isEnabled()) {
+                EntityPlayer player = getLocalPlayer();
+                if (player != null) updateStepHeight(player);
+              }
+            });
           })
           .build();
 

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -153,7 +153,7 @@ public class StepMod extends ToggleMod {
   }
 
   @Override
-  public String getDisplayText() {
+  public String getDebugDisplayText() {
     return String.format(
         "%s[%s%s]",
         super.getDisplayText(),

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -89,10 +89,10 @@ public class StepMod extends ToggleMod {
     player.setPositionAndUpdate(player.posX, newY.get(), player.posZ);
   }
 
-  public void updateUnstep(EntityPlayer player) {
+  private void updateUnstep(EntityPlayer player) {
     try {
       if (unstep.get() && wasOnGround && !player.onGround && player.motionY <= 0) {
-        unstep(player);
+        MC.addScheduledTask(() -> unstep(player));
       }
     } finally {
       wasOnGround = player.onGround;

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -32,14 +32,12 @@ public class StepMod extends ToggleMod {
           .description("how high you can step")
           .defaultTo(1.2f)
           .min(0f)
-          .success(__ -> {
-            MC.addScheduledTask(() -> {
-              if (isEnabled()) {
-                EntityPlayer player = getLocalPlayer();
-                if (player != null) updateStepHeight(player);
-              }
-            });
-          })
+          .changed(__ -> MC.addScheduledTask(() -> {
+            if (isEnabled()) {
+              EntityPlayer player = getLocalPlayer();
+              if (player != null) updateStepHeight(player);
+            }
+          }))
           .build();
 
   public final Setting<Boolean> unstep =

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -73,12 +73,9 @@ public class StepMod extends ToggleMod {
     }
   }
 
-  public boolean wasOnGround = false;
+  private boolean wasOnGround = false;
 
   public void unstep(EntityPlayer player) {
-    if (!MC.isCallingFromMinecraftThread())
-      throw new IllegalStateException("Call this using MC.addScheduledTask");
-
     AxisAlignedBB range = player.getEntityBoundingBox().expand(0, -stepHeight.get(), 0).contract(0, player.height, 0);
 
     if (!player.world.collidesWithAnyBlock(range)) return;
@@ -92,7 +89,7 @@ public class StepMod extends ToggleMod {
   public void updateUnstep(EntityPlayer player) {
     try {
       if (unstep.get() && wasOnGround && !player.onGround && player.motionY <= 0) {
-        MC.addScheduledTask(() -> unstep(player));
+        unstep(player);
       }
     } finally {
       wasOnGround = player.onGround;

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -66,18 +66,12 @@ public class StepMod extends ToggleMod {
   }
 
   private void updateStepHeight(EntityPlayer player) {
-    if (!MC.isCallingFromMinecraftThread())
-      throw new IllegalStateException("This function must be called from the main thread");
-
     player.stepHeight = player.onGround ? stepHeight.get() : DEFAULT_STEP_HEIGHT;
   }
 
   private boolean wasOnGround = false;
 
   private void unstep(EntityPlayer player) {
-    if (!MC.isCallingFromMinecraftThread())
-      throw new IllegalStateException("This function must be called from the main thread");
-
     AxisAlignedBB range = player.getEntityBoundingBox().expand(0, -stepHeight.get(), 0).contract(0, player.height, 0);
 
     if (!player.world.collidesWithAnyBlock(range)) return;
@@ -89,9 +83,6 @@ public class StepMod extends ToggleMod {
   }
 
   private void updateUnstep(EntityPlayer player) {
-    if (!MC.isCallingFromMinecraftThread())
-      throw new IllegalStateException("This function must be called from the main thread");
-
     try {
       if (unstep.get() && wasOnGround && !player.onGround && player.motionY <= 0) {
         unstep(player);

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -75,7 +75,10 @@ public class StepMod extends ToggleMod {
 
   private boolean wasOnGround = false;
 
-  public void unstep(EntityPlayer player) {
+  private void unstep(EntityPlayer player) {
+    if (!MC.isCallingFromMinecraftThread())
+      throw new IllegalStateException("This function must be called from the main thread");
+
     AxisAlignedBB range = player.getEntityBoundingBox().expand(0, -stepHeight.get(), 0).contract(0, player.height, 0);
 
     if (!player.world.collidesWithAnyBlock(range)) return;


### PR DESCRIPTION
`unstep` is a configuration option of Step that allows you to instantly teleport down from blocks when walking off of them, rather than falling.

This is not designed to bypass anticheats or cancel fall damage. It also does not currently check for Jesus when stepping down more than 1 block onto water.