### PR TITLE
LightningFinder

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/LightningFinder.java
+++ b/src/main/java/com/matt/forgehax/mods/LightningFinder.java
@@ -46,14 +46,16 @@ public class LightningFinder extends ToggleMod {
   protected void onEnabled() {
     super.onEnabled();
 
-    if (warning.get())
-      MC.addScheduledTask(() -> printWarning(
-          "Warning: Spigot (and forks) have patched this lightning exploit and don't provide absolute coordinates." +
-              " This is still safe to use on Vanilla and Forge servers. This warning message will be disabled now;" +
-              " you can enable it again with the 'warning' setting."
-      ));
+    if (warning.get()) {
+      MC.addScheduledTask(() -> {
+        printWarning(
+            "Warning: Spigot (and forks) have patched this lightning exploit and don't provide absolute coordinates." +
+                " This is still safe to use on Vanilla and Forge servers."
+        );
 
-    warning.set(false, true);
+        warning.set(false);
+      });
+    }
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/LightningFinder.java
+++ b/src/main/java/com/matt/forgehax/mods/LightningFinder.java
@@ -25,6 +25,9 @@ public class LightningFinder extends ToggleMod {
           .name("warning")
           .description("warn about the patch")
           .defaultTo(true)
+          .changed(change -> {
+            if (isEnabled() && change.getTo()) MC.addScheduledTask(this::doWarning);
+          })
           .build();
 
   @SuppressWarnings("WeakerAccess")
@@ -42,20 +45,20 @@ public class LightningFinder extends ToggleMod {
     super(Category.MISC, "LightningFinder", false, "Logs positions of lightning strikes to chat");
   }
 
+  private void doWarning() {
+    printWarning(
+        "Warning: Spigot (and forks) have patched this lightning exploit and don't provide absolute coordinates." +
+            " This is still safe to use on Vanilla and Forge servers."
+    );
+
+    warning.set(false);
+  }
+
   @Override
   protected void onEnabled() {
     super.onEnabled();
 
-    if (warning.get()) {
-      MC.addScheduledTask(() -> {
-        printWarning(
-            "Warning: Spigot (and forks) have patched this lightning exploit and don't provide absolute coordinates." +
-                " This is still safe to use on Vanilla and Forge servers."
-        );
-
-        warning.set(false);
-      });
-    }
+    if (warning.get()) MC.addScheduledTask(this::doWarning);
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/LightningFinder.java
+++ b/src/main/java/com/matt/forgehax/mods/LightningFinder.java
@@ -17,7 +17,6 @@ import static com.matt.forgehax.Helper.printWarning;
 
 @RegisterMod
 public class LightningFinder extends ToggleMod {
-  @SuppressWarnings("WeakerAccess")
   public final Setting<Boolean> warning =
       getCommandStub()
           .builders()

--- a/src/main/java/com/matt/forgehax/mods/LightningFinder.java
+++ b/src/main/java/com/matt/forgehax/mods/LightningFinder.java
@@ -1,0 +1,88 @@
+package com.matt.forgehax.mods;
+
+import com.matt.forgehax.asm.events.PacketEvent;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.network.play.server.SPacketSoundEffect;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import static com.matt.forgehax.Helper.getLocalPlayer;
+import static com.matt.forgehax.Helper.printInform;
+import static com.matt.forgehax.Helper.printWarning;
+
+@RegisterMod
+public class LightningFinder extends ToggleMod {
+  @SuppressWarnings("WeakerAccess")
+  public final Setting<Boolean> warning =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("warning")
+          .description("warn about the patch")
+          .defaultTo(true)
+          .build();
+
+  @SuppressWarnings("WeakerAccess")
+  public final Setting<Integer> minDistance =
+      getCommandStub()
+          .builders()
+          .<Integer>newSettingBuilder()
+          .name("min-distance")
+          .description("how far the strike has to be from you")
+          .min(0)
+          .defaultTo(32)
+          .build();
+
+  public LightningFinder() {
+    super(Category.MISC, "LightningFinder", false, "Logs positions of lightning strikes to chat");
+  }
+
+  @Override
+  protected void onEnabled() {
+    super.onEnabled();
+
+    if (warning.get())
+      MC.addScheduledTask(() -> printWarning(
+          "Warning: Spigot (and forks) have patched this lightning exploit and don't provide absolute coordinates." +
+              " This is still safe to use on Vanilla and Forge servers. This warning message will be disabled now;" +
+              " you can enable it again with the 'warning' setting."
+      ));
+
+    warning.set(false, true);
+  }
+
+  @SubscribeEvent
+  public void onPacketRecieving(PacketEvent.Incoming.Pre event) {
+    if (!(event.getPacket() instanceof SPacketSoundEffect)) return;
+
+    SPacketSoundEffect packet = event.getPacket();
+
+    // in the SPacketSpawnGlobalEntity constructor, this is only set to 1 if it's a lightning bolt
+    if (packet.getSound() != SoundEvents.ENTITY_LIGHTNING_THUNDER) return;
+
+    BlockPos pos = new BlockPos(packet.getX(), packet.getY(), packet.getZ());
+    EntityPlayer player = getLocalPlayer();
+
+    if (player.getDistanceSqToCenter(pos) >= Math.pow(minDistance.get(), 2))
+      MC.addScheduledTask(() -> printInform(
+          "Lightning just struck @ [x:%d, y:%d, z:%d]",
+          pos.getX(),
+          pos.getY(),
+          pos.getZ()
+      ));
+  }
+
+  @Override
+  public String getDebugDisplayText() {
+    return String.format(
+        "%s[>%d]",
+        super.getDisplayText(),
+        minDistance.get()
+    );
+  }
+}


### PR DESCRIPTION
On servers without this exploit patched (i.e. not Spigot) this mod can be used to find the position of lightning strikes, no matter where they are in the world. This is the exploit that caused 2b to disable lightning.

![image](https://user-images.githubusercontent.com/4723091/63586913-7529a180-c557-11e9-93fd-07fd10eccf66.png)

The mod supports specifying a minimum range so that lightning strikes close to you don't get logged:

![image](https://user-images.githubusercontent.com/4723091/63586934-85418100-c557-11e9-98b0-3385c5e6620f.png)

The mod also prints a warning to chat the first time it's enabled:

![image](https://user-images.githubusercontent.com/4723091/63586729-ea48a700-c556-11e9-92a1-98d07ead29c6.png)

Make sure to let me know if that's too much, I could easily remove it.