### PR TITLE
Add VanillaFly

### DIFF
--- a/src/main/java/com/matt/forgehax/asm/reflection/FastReflection.java
+++ b/src/main/java/com/matt/forgehax/asm/reflection/FastReflection.java
@@ -99,24 +99,49 @@ public interface FastReflection extends ASMCommon {
             .setName("yaw")
             .autoAssign()
             .asField();
+
+    FastField<Boolean> CPacketPlayer_moving =
+        FastTypeBuilder.create()
+            .setInsideClass(CPacketPlayer.class)
+            .setName("moving")
+            .autoAssign()
+            .asField();
+
     FastField<Boolean> CPacketPlayer_rotating =
         FastTypeBuilder.create()
             .setInsideClass(CPacketPlayer.class)
             .setName("rotating")
             .autoAssign()
             .asField();
+
     FastField<Boolean> CPacketPlayer_onGround =
         FastTypeBuilder.create()
             .setInsideClass(CPacketPlayer.class)
             .setName("onGround")
             .autoAssign()
             .asField();
-    FastField<Double> CPacketPlayer_Y =
+
+    FastField<Double> CPacketPlayer_x =
+        FastTypeBuilder.create()
+            .setInsideClass(CPacketPlayer.class)
+            .setName("x")
+            .autoAssign()
+            .asField();
+
+    FastField<Double> CPacketPlayer_y =
         FastTypeBuilder.create()
             .setInsideClass(CPacketPlayer.class)
             .setName("y")
             .autoAssign()
             .asField();
+
+    FastField<Double> CPacketPlayer_z =
+        FastTypeBuilder.create()
+            .setInsideClass(CPacketPlayer.class)
+            .setName("z")
+            .autoAssign()
+            .asField();
+
     /** CPacketVehicleMove */
     FastField<Float> CPacketVehicleMove_yaw =
         FastTypeBuilder.create()
@@ -153,6 +178,27 @@ public interface FastReflection extends ASMCommon {
         FastTypeBuilder.create()
             .setInsideClass(SPacketPlayerPosLook.class)
             .setName("yaw")
+            .autoAssign()
+            .asField();
+
+    FastField<Double> SPacketPlayer_x =
+        FastTypeBuilder.create()
+            .setInsideClass(SPacketPlayerPosLook.class)
+            .setName("x")
+            .autoAssign()
+            .asField();
+
+    FastField<Double> SPacketPlayer_y =
+        FastTypeBuilder.create()
+            .setInsideClass(SPacketPlayerPosLook.class)
+            .setName("y")
+            .autoAssign()
+            .asField();
+
+    FastField<Double> SPacketPlayer_z =
+        FastTypeBuilder.create()
+            .setInsideClass(SPacketPlayerPosLook.class)
+            .setName("z")
             .autoAssign()
             .asField();
 

--- a/src/main/java/com/matt/forgehax/mods/Jesus.java
+++ b/src/main/java/com/matt/forgehax/mods/Jesus.java
@@ -72,8 +72,8 @@ public class Jesus extends ToggleMod {
           && !isInWater(getLocalPlayer())
           && !isAboveLand(getLocalPlayer())) {
         int ticks = getLocalPlayer().ticksExisted % 2;
-        double y = FastReflection.Fields.CPacketPlayer_Y.get(event.getPacket());
-        if (ticks == 0) FastReflection.Fields.CPacketPlayer_Y.set(event.getPacket(), y + 0.02D);
+        double y = FastReflection.Fields.CPacketPlayer_y.get(event.getPacket());
+        if (ticks == 0) FastReflection.Fields.CPacketPlayer_y.set(event.getPacket(), y + 0.02D);
       }
     }
   }

--- a/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
+++ b/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
@@ -34,6 +34,17 @@ public class VanillaFlyMod extends ToggleMod {
           .defaultTo(false)
           .build();
 
+  @SuppressWarnings("WeakerAccess")
+  public final Setting<Float> flySpeed =
+      getCommandStub()
+          .builders()
+          .<Float>newSettingBuilder()
+          .name("speed")
+          .description("fly speed as a multiplier of the default")
+          .min(0f)
+          .defaultTo(1f)
+          .build();
+
   public VanillaFlyMod() {
     super(Category.PLAYER, "VanillaFly", false, "Fly like creative mode");
   }
@@ -58,6 +69,8 @@ public class VanillaFlyMod extends ToggleMod {
       fly.enable();
       player.capabilities.isFlying = false;
     }
+
+    player.capabilities.setFlySpeed(0.05f * flySpeed.get());
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
+++ b/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
@@ -24,6 +24,7 @@ import static java.util.Objects.isNull;
 public class VanillaFlyMod extends ToggleMod {
   private Handle fly = getFlySwitch().createHandle(getModName());
 
+  @SuppressWarnings("WeakerAccess")
   public final Setting<Boolean> groundSpoof =
       getCommandStub()
           .builders()
@@ -55,6 +56,7 @@ public class VanillaFlyMod extends ToggleMod {
     if (!player.capabilities.allowFlying) {
       fly.disable();
       fly.enable();
+      player.capabilities.isFlying = false;
     }
   }
 

--- a/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
+++ b/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
@@ -1,6 +1,7 @@
 package com.matt.forgehax.mods;
 
 import com.matt.forgehax.asm.events.PacketEvent;
+import com.matt.forgehax.asm.reflection.FastReflection.Fields;
 import com.matt.forgehax.events.LocalPlayerUpdateEvent;
 import com.matt.forgehax.util.Switch.Handle;
 import com.matt.forgehax.util.command.Setting;
@@ -9,8 +10,8 @@ import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.play.client.CPacketPlayer;
+import net.minecraft.network.play.server.SPacketPlayerPosLook;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.util.List;
@@ -32,6 +33,16 @@ public class VanillaFlyMod extends ToggleMod {
           .name("spoof")
           .description("make the server think we are on the ground while flying")
           .defaultTo(false)
+          .build();
+
+  @SuppressWarnings("WeakerAccess")
+  public final Setting<Boolean> antiGround =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("antiground")
+          .description("attempts to prevent the server from teleporting us to the ground")
+          .defaultTo(true)
           .build();
 
   @SuppressWarnings("WeakerAccess")
@@ -82,16 +93,48 @@ public class VanillaFlyMod extends ToggleMod {
       return;
 
     CPacketPlayer packet = event.getPacket();
-
-    if (!(boolean) ObfuscationReflectionHelper.getPrivateValue(CPacketPlayer.class, packet, "moving", "field_149480_h", "g"))
-      return;
+    if (!Fields.CPacketPlayer_moving.get(packet)) return;
 
     AxisAlignedBB range = player.getEntityBoundingBox().expand(0, -player.posY, 0).contract(0, -player.height, 0);
     List<AxisAlignedBB> collisionBoxes = player.world.getCollisionBoxes(player, range);
     AtomicReference<Double> newHeight = new AtomicReference<>(0D);
     collisionBoxes.forEach(box -> newHeight.set(Math.max(newHeight.get(), box.maxY)));
 
-    ObfuscationReflectionHelper.setPrivateValue(CPacketPlayer.class, packet, newHeight.get(), "y", "field_149477_b", "b");
-    ObfuscationReflectionHelper.setPrivateValue(CPacketPlayer.class, packet, true, "onGround", "field_149474_g", "f");
+    Fields.CPacketPlayer_y.set(packet, newHeight.get());
+    Fields.CPacketPlayer_onGround.set(packet, true);
+  }
+
+  @SubscribeEvent
+  public void onPacketRecieving(PacketEvent.Incoming.Pre event) {
+    EntityPlayer player = getLocalPlayer();
+    if (isNull(player)) return;
+
+    if (!antiGround.get() || !(event.getPacket() instanceof SPacketPlayerPosLook) || !player.capabilities.isFlying)
+      return;
+
+    SPacketPlayerPosLook packet = event.getPacket();
+
+    double oldY = player.posY;
+    player.setPosition(
+        Fields.SPacketPlayer_x.get(packet),
+        Fields.SPacketPlayer_y.get(packet),
+        Fields.SPacketPlayer_z.get(packet)
+    );
+
+    /*
+     * This needs a little explanation, as I had a little trouble wrapping my head around it myself.
+     * Basically, we're trying to find a new position that's as close to the original height as possible.
+     * That way, if you're, for example, spoofing and the server rubberbands you back, you don't go back to the ground.
+     * This tries to find the lowest block above the spot the server teleported you to, and teleport you right to that.
+     * If the lowest block is below where you were before, it just teleports you to where you were before.
+     * This allows VanillaFly to be slightly more usable on servers like Constantiam that like to teleport you in place
+     * to hopefully disable fly hacks. Well, sorry guys, this fly hack is smarter than that.
+     */
+    AxisAlignedBB range = player.getEntityBoundingBox().expand(0, 256 - player.height - player.posY, 0).contract(0, player.height, 0);
+    List<AxisAlignedBB> collisionBoxes = player.world.getCollisionBoxes(player, range);
+    AtomicReference<Double> newY = new AtomicReference<>(256D);
+    collisionBoxes.forEach(box -> newY.set(Math.min(newY.get(), box.minY - player.height)));
+
+    Fields.SPacketPlayer_y.set(packet, Math.min(oldY, newY.get()));
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
+++ b/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
@@ -1,0 +1,82 @@
+package com.matt.forgehax.mods;
+
+import com.matt.forgehax.asm.events.PacketEvent;
+import com.matt.forgehax.events.LocalPlayerUpdateEvent;
+import com.matt.forgehax.util.Switch.Handle;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.network.play.client.CPacketPlayer;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.matt.forgehax.Helper.getLocalPlayer;
+import static com.matt.forgehax.util.entity.LocalPlayerUtils.getFlySwitch;
+import static java.util.Objects.isNull;
+
+@RegisterMod
+public class VanillaFlyMod extends ToggleMod {
+  private Handle fly = getFlySwitch().createHandle(getModName());
+
+  public final Setting<Boolean> groundSpoof =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("spoof")
+          .description("make the server think we are on the ground while flying")
+          .defaultTo(false)
+          .build();
+
+  public VanillaFlyMod() {
+    super(Category.PLAYER, "VanillaFly", false, "Fly like creative mode");
+  }
+
+  @Override
+  protected void onEnabled() {
+    fly.enable();
+  }
+
+  @Override
+  protected void onDisabled() {
+    fly.disable();
+  }
+
+  @SubscribeEvent
+  public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
+    EntityPlayer player = getLocalPlayer();
+    if (isNull(player)) return;
+
+    if (!player.capabilities.allowFlying) {
+      fly.disable();
+      fly.enable();
+    }
+  }
+
+  @SubscribeEvent
+  public void onPacketSending(PacketEvent.Outgoing.Pre event) {
+    EntityPlayer player = getLocalPlayer();
+    if (isNull(player)) return;
+
+    if (!groundSpoof.get() || !(event.getPacket() instanceof CPacketPlayer) || !player.capabilities.isFlying)
+      return;
+
+    CPacketPlayer packet = event.getPacket();
+
+    if (!(boolean) ObfuscationReflectionHelper.getPrivateValue(CPacketPlayer.class, packet, "moving", "field_149480_h", "g"))
+      return;
+
+    AxisAlignedBB range = player.getEntityBoundingBox().expand(0, -player.posY, 0).contract(0, -player.height, 0);
+    List<AxisAlignedBB> collisionBoxes = player.world.getCollisionBoxes(player, range);
+    AtomicReference<Double> newHeight = new AtomicReference<>(0D);
+    collisionBoxes.forEach(box -> newHeight.set(Math.max(newHeight.get(), box.maxY)));
+
+    ObfuscationReflectionHelper.setPrivateValue(CPacketPlayer.class, packet, newHeight.get(), "y", "field_149477_b", "b");
+    ObfuscationReflectionHelper.setPrivateValue(CPacketPlayer.class, packet, true, "onGround", "field_149474_g", "f");
+  }
+}


### PR DESCRIPTION
Introducing VanillaFly. Unlike regular Fly, this one actually works. This just re-enables the fly capability as if you were in creative mode.

BUT WAIT, THERE'S MORE! We all know that some (most) servers have fly disabled. This means that even if you get past the anticheat, it'll kick you after 40 ticks. What can we do to prevent this? Spoof packets, of course.

With VanillaFly active, you can turn on the `spoof` option (disabled by default) to make the server think you are on the ground. You can still fly around to your heart's content client-side. This will also (hopefully) prevent fall damage on vanilla servers, even with fly enabled.

![Gif](https://puu.sh/E8BjZ/0dedf129db.gif) @ https://puu.sh/E8BjZ/0dedf129db.gif