### PR TITLE
Add Blink (Fixes #94)

### DIFF
--- a/src/main/java/com/matt/forgehax/mods/BlinkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/BlinkMod.java
@@ -18,6 +18,7 @@ import static com.matt.forgehax.Helper.getLocalPlayer;
 import static com.matt.forgehax.Helper.getWorld;
 import static com.matt.forgehax.Helper.printMessage;
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 /**
  * Coded by LoganDark on 8/22/2019
@@ -69,12 +70,12 @@ public class BlinkMod extends ToggleMod {
 
   @Override
   protected void onDisabled() {
-    if (!isNull(ghost)) {
+    if (nonNull(ghost)) {
       removeGhostPlayer();
       ghost = null;
     }
 
-    if (!isNull(packets)) {
+    if (nonNull(packets)) {
       packets.forEach(PacketHelper::ignoreAndSend);
       packets = null;
     }
@@ -84,7 +85,7 @@ public class BlinkMod extends ToggleMod {
 
   @SubscribeEvent
   public void onPacketSending(PacketEvent.Outgoing.Pre event) {
-    if (!isNull(packets)) {
+    if (nonNull(packets)) {
       event.setCanceled(true);
       packets.add(event.getPacket());
     }

--- a/src/main/java/com/matt/forgehax/mods/BlinkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/BlinkMod.java
@@ -1,0 +1,98 @@
+package com.matt.forgehax.mods;
+
+import com.matt.forgehax.asm.events.PacketEvent;
+import com.matt.forgehax.events.LocalPlayerUpdateEvent;
+import com.matt.forgehax.util.PacketHelper;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.client.entity.EntityOtherPlayerMP;
+import net.minecraft.client.multiplayer.WorldClient;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.network.Packet;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import static com.matt.forgehax.Helper.*;
+import static java.util.Objects.isNull;
+
+/**
+ * Coded by LoganDark on 8/22/2019
+ */
+@RegisterMod
+public class BlinkMod extends ToggleMod {
+  private static final int GHOST_ID = -101;
+
+  public BlinkMod() {
+    super(Category.PLAYER, "Blink", false, "Simulate lag to teleport short distances");
+  }
+
+  private ConcurrentLinkedDeque<Packet<?>> packets;
+  private EntityOtherPlayerMP ghost;
+  private boolean disablePlease = false;
+
+  private boolean setGhostPlayer() {
+    EntityPlayer player = getLocalPlayer();
+    WorldClient world = getWorld();
+    if (isNull(player) || isNull(world)) return false;
+
+    ghost = new EntityOtherPlayerMP(world, MC.getSession().getProfile());
+    ghost.copyLocationAndAnglesFrom(player);
+    ghost.rotationYawHead = player.rotationYawHead;
+    ghost.inventory = player.inventory;
+    ghost.inventoryContainer = player.inventoryContainer;
+    world.addEntityToWorld(GHOST_ID, ghost);
+
+    return true;
+  }
+
+  @Override
+  protected void onEnabled() {
+    super.onEnabled();
+
+    if (MC.isSingleplayer()) {
+      printMessage("Sorry, Blink doesn't work in singleplayer at the moment...");
+      disablePlease = true;
+      return;
+    }
+
+    packets = new ConcurrentLinkedDeque<>();
+    if (!setGhostPlayer()) disablePlease = true;
+  }
+
+  private void removeGhostPlayer() {
+    ghost.world.removeEntity(ghost);
+  }
+
+  @Override
+  protected void onDisabled() {
+    if (!isNull(ghost)) {
+      removeGhostPlayer();
+      ghost = null;
+    }
+
+    if (!isNull(packets)) {
+      packets.forEach(PacketHelper::ignoreAndSend);
+      packets = null;
+    }
+
+    super.onDisabled();
+  }
+
+  @SubscribeEvent
+  public void onPacketSending(PacketEvent.Outgoing.Pre event) {
+    if (!isNull(packets)) {
+      event.setCanceled(true);
+      packets.add(event.getPacket());
+    }
+  }
+
+  @SubscribeEvent
+  public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
+    if (disablePlease) {
+      disablePlease = false;
+      disable();
+    }
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/BlinkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/BlinkMod.java
@@ -14,7 +14,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-import static com.matt.forgehax.Helper.*;
+import static com.matt.forgehax.Helper.getLocalPlayer;
+import static com.matt.forgehax.Helper.getWorld;
+import static com.matt.forgehax.Helper.printMessage;
 import static java.util.Objects.isNull;
 
 /**

--- a/src/main/java/com/matt/forgehax/mods/BlinkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/BlinkMod.java
@@ -1,7 +1,6 @@
 package com.matt.forgehax.mods;
 
 import com.matt.forgehax.asm.events.PacketEvent;
-import com.matt.forgehax.events.LocalPlayerUpdateEvent;
 import com.matt.forgehax.util.PacketHelper;
 import com.matt.forgehax.util.mod.Category;
 import com.matt.forgehax.util.mod.ToggleMod;
@@ -16,7 +15,6 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 
 import static com.matt.forgehax.Helper.getLocalPlayer;
 import static com.matt.forgehax.Helper.getWorld;
-import static com.matt.forgehax.Helper.printMessage;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
@@ -33,7 +31,6 @@ public class BlinkMod extends ToggleMod {
 
   private ConcurrentLinkedDeque<Packet<?>> packets;
   private EntityOtherPlayerMP ghost;
-  private boolean disablePlease = false;
 
   private boolean setGhostPlayer() {
     EntityPlayer player = getLocalPlayer();
@@ -54,14 +51,8 @@ public class BlinkMod extends ToggleMod {
   protected void onEnabled() {
     super.onEnabled();
 
-    if (MC.isSingleplayer()) {
-      printMessage("Sorry, Blink doesn't work in singleplayer at the moment...");
-      disablePlease = true;
-      return;
-    }
-
     packets = new ConcurrentLinkedDeque<>();
-    if (!setGhostPlayer()) disablePlease = true;
+    if (!setGhostPlayer()) disable();
   }
 
   private void removeGhostPlayer() {
@@ -85,17 +76,9 @@ public class BlinkMod extends ToggleMod {
 
   @SubscribeEvent
   public void onPacketSending(PacketEvent.Outgoing.Pre event) {
-    if (nonNull(packets)) {
+    if (nonNull(packets) && event.getPacket().getClass().getCanonicalName().startsWith("net.minecraft.network.play.client")) {
       event.setCanceled(true);
       packets.add(event.getPacket());
-    }
-  }
-
-  @SubscribeEvent
-  public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
-    if (disablePlease) {
-      disablePlease = false;
-      disable();
     }
   }
 }


### PR DESCRIPTION
Blink is a mod that queues (and stops sending) packets to the server while active, then when disabled sends all the queued packets at once. This can be used to teleport by making the server think we're lagging.

Only merge if you are comfortable with the nasty hack on line 79