### PR TITLE
Add Resource annotation to transformer for better Mixin compatibility

### DIFF
--- a/src/main/java/com/matt/forgehax/asm/ForgeHaxTransformer.java
+++ b/src/main/java/com/matt/forgehax/asm/ForgeHaxTransformer.java
@@ -37,6 +37,9 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
 
+import javax.annotation.Resource;
+
+@Resource // will mark this transformer as a legacy transformer and stop mixin from causing problems
 @IFMLLoadingPlugin.SortingIndex(1001)
 public class ForgeHaxTransformer implements IClassTransformer, ASMCommon {
   


### PR DESCRIPTION
Mixin checks all transformers for this annotation and marks them as legacy transformers.
Might help fix some problems I've been having with mixin.