### PR TITLE
Add package.json with handy npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "forgehax",
+  "version": "2.9.0",
+  "description": "hax 4 forge",
+  "main": "index.js",
+  "scripts": {
+    "setup-decompilation-workspace": "scripts/update",
+    "compile-forgehax": "scripts/cibuild"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Fr1kin/ForgeHax.git"
+  },
+  "keywords": [
+    "minecraft",
+    "cheat",
+    "java"
+  ],
+  "author": "Fr1kin Babbaj",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Fr1kin/ForgeHax/issues"
+  },
+  "homepage": "https://github.com/Fr1kin/ForgeHax#readme"
+}


### PR DESCRIPTION
Running the shell scripts in the `scripts` folder manually is an outdated and annoying way of doing things.

This PR adds support for handy [npm run](https://docs.npmjs.com/cli/run-script) scripts that will allow ForgeHax developers to easily run the CI deployment scripts locally in a user friendly way.
Another advantage of introduceing `npm` into the ForgeHax development workflow is that it will make ForgeHax use state of the art web technologies and thus render the entire project web scale.

With this PR, you can easily setup the MCP development workspace by running:
```bash
npm run setup-decompilation-workspace
```
To compile a release `jar` version of ForgeHax, run:
```bash
npm run compile-forgehax
```