### PR TITLE
Make CI scripts work anywhere

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,7 +2,6 @@ version: '2.3'
 services:
     forgehax:
         image: gradle:5.4-jdk8
-        user: "1002:1002"
         environment:
           - GIT_COMMIT=${GIT_COMMIT:-latest}
           - FORGEHAX_DEBUG=1

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -27,6 +27,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \
             -f docker-compose.ci.yml \
             run --rm \
+            --user "$(id -u):$(id -g)" \
             forgehax build --stacktrace -Djenkins
     fi
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -21,11 +21,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         docker-compose \
             -f docker-compose.ci.yml \
             run --rm \
+            --user "$(id -u):$(id -g)" \
             forgehax clean --stacktrace
-
-#        docker-compose \
-#            -f docker-compose.ci.yml \
-#            run --rm \
-#            forgehax setupDecompWorkspace --stacktrace --refresh-dependencies
     fi
 fi


### PR DESCRIPTION
Run the gradle containers using the uid/gid of the person running them rather than the hardcoded uid/gid on our Jenkins server.