### PR TITLE
Allow to hide mods from modlist

### DIFF
--- a/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
@@ -1,7 +1,7 @@
 package com.matt.forgehax.util.mod;
-
+  
 import static com.matt.forgehax.Helper.getGlobalCommand;
-
+  
 import com.matt.forgehax.Globals;
 import com.matt.forgehax.util.command.Command;
 import com.matt.forgehax.util.command.ExecuteData;
@@ -12,21 +12,21 @@ import java.util.Collection;
 import java.util.Collections;
 import joptsimple.internal.Strings;
 import net.minecraftforge.common.MinecraftForge;
-
+  
 public abstract class BaseMod implements Globals {
-
+  
   // name of the mod
   private final String modName;
   // description of mod
   private final String modDescription;
   // category of the mod
   private final Category category;
-
+  
   protected final Command stubCommand;
-
+  
   // is the mod registered on the forge bus?
   private boolean registered = false;
-
+  
   public BaseMod(Category category, String name, String desc) {
     this.modName = name;
     this.modDescription = desc;
@@ -41,11 +41,11 @@ public abstract class BaseMod implements Globals {
                 .processor(this::onProcessCommand))
             .build();
   }
-
+  
   public BaseMod(Category category, String name) {
     this(category, name, Strings.EMPTY);
   }
-
+  
   /**
    * Load the mod
    */
@@ -58,7 +58,7 @@ public abstract class BaseMod implements Globals {
     }
     onLoad();
   }
-
+  
   /**
    * Unload the mod
    */
@@ -71,7 +71,7 @@ public abstract class BaseMod implements Globals {
       stubCommand.leaveParent();
     }
   }
-
+  
   /**
    * Enables the mod
    */
@@ -81,65 +81,65 @@ public abstract class BaseMod implements Globals {
       LOGGER.info(String.format("%s enabled", getModName()));
     }
   }
-
+  
   protected final void stop() {
     if (unregister()) {
       onDisabled();
       LOGGER.info(String.format("%s disabled", getModName()));
     }
   }
-
+  
   public void enable() {
     start();
   }
-
+  
   public void disable() {
     stop();
   }
-
+  
   public void hide() {
     return;
   }
-
+  
   public void show() {
     return;
   }
-
+  
   /**
    * Get the categories name
    */
   public final String getModName() {
     return modName;
   }
-
+  
   /**
    * Get mod description
    */
   public final String getModDescription() {
     return modDescription;
   }
-
+  
   /**
    * Get mod category
    */
   public Category getModCategory() {
     return category;
   }
-
+  
   /**
    * The main mod command
    */
   public Command getCommandStub() {
     return stubCommand;
   }
-
+  
   /**
    * Check if mod is currently registered
    */
   public final boolean isRegistered() {
     return registered;
   }
-
+  
   /**
    * Register event to forge bus
    */
@@ -152,7 +152,7 @@ public abstract class BaseMod implements Globals {
       return false;
     }
   }
-
+  
   /**
    * Unregister event on forge bus
    */
@@ -165,11 +165,11 @@ public abstract class BaseMod implements Globals {
       return false;
     }
   }
-
+  
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder;
   }
-
+  
   @SuppressWarnings("unchecked")
   public final <T extends Command> T getCommand(String commandName) {
     try {
@@ -178,11 +178,11 @@ public abstract class BaseMod implements Globals {
       return null;
     }
   }
-
+  
   public final Setting<?> getSetting(String settingName) {
     return getCommand(settingName);
   }
-
+  
   public final Collection<Command> getCommands() {
     if (stubCommand != null) {
       return stubCommand.getChildren();
@@ -190,17 +190,17 @@ public abstract class BaseMod implements Globals {
       return Collections.emptyList();
     }
   }
-
+  
   /**
    * Check if the mod is hidden DEFAULT: true
    */
   public abstract boolean isHidden();
-
+  
   /**
    * Check if the mod is enabled
    */
   public abstract boolean isEnabled();
-
+  
   private void writeChildren(
       StringBuilder builder, Command command, final boolean deep, final String append) {
     command
@@ -220,7 +220,7 @@ public abstract class BaseMod implements Globals {
               }
             });
   }
-
+  
   protected void onProcessCommand(ExecuteData data) {
     if (data.getArgumentCount() == 0 && !data.options().hasOptions()) {
       final StringBuilder builder = new StringBuilder();
@@ -228,45 +228,45 @@ public abstract class BaseMod implements Globals {
       data.write(builder.toString());
     }
   }
-
+  
   /**
    * Called when the mod is loaded
    */
   protected abstract void onLoad();
-
+  
   /**
    * Called when unloaded
    */
   protected abstract void onUnload();
-
+  
   /**
    * Called when the mod is enabled
    */
   protected abstract void onEnabled();
-
+  
   /**
    * Called when the mod is disabled
    */
   protected abstract void onDisabled();
-
+  
   /**
    * Called when the bind is initially pressed
    */
   protected abstract void onBindPressed(CallbackData cb);
-
+  
   /**
    * Called while the bind key is pressed down
    */
   protected abstract void onBindKeyDown(CallbackData cb);
-
+  
   public String getDisplayText() {
     return getModName();
   }
-
+  
   public String getDebugDisplayText() {
     return getDisplayText();
   }
-
+  
   @Override
   public String toString() {
     return getModName() + ": " + getModDescription();

--- a/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
@@ -14,19 +14,19 @@ import joptsimple.internal.Strings;
 import net.minecraftforge.common.MinecraftForge;
 
 public abstract class BaseMod implements Globals {
-  
+
   // name of the mod
   private final String modName;
   // description of mod
   private final String modDescription;
   // category of the mod
   private final Category category;
-  
+
   protected final Command stubCommand;
-  
+
   // is the mod registered on the forge bus?
   private boolean registered = false;
-  
+
   public BaseMod(Category category, String name, String desc) {
     this.modName = name;
     this.modDescription = desc;
@@ -41,11 +41,11 @@ public abstract class BaseMod implements Globals {
                 .processor(this::onProcessCommand))
             .build();
   }
-  
+
   public BaseMod(Category category, String name) {
     this(category, name, Strings.EMPTY);
   }
-  
+
   /**
    * Load the mod
    */
@@ -58,7 +58,7 @@ public abstract class BaseMod implements Globals {
     }
     onLoad();
   }
-  
+
   /**
    * Unload the mod
    */
@@ -71,7 +71,7 @@ public abstract class BaseMod implements Globals {
       stubCommand.leaveParent();
     }
   }
-  
+
   /**
    * Enables the mod
    */
@@ -81,57 +81,65 @@ public abstract class BaseMod implements Globals {
       LOGGER.info(String.format("%s enabled", getModName()));
     }
   }
-  
+
   protected final void stop() {
     if (unregister()) {
       onDisabled();
       LOGGER.info(String.format("%s disabled", getModName()));
     }
   }
-  
+
   public void enable() {
     start();
   }
-  
+
   public void disable() {
     stop();
   }
-  
+
+  public void hide() {
+    return;
+  }
+
+  public void show() {
+    return;
+  }
+
   /**
    * Get the categories name
    */
   public final String getModName() {
     return modName;
   }
-  
+
   /**
    * Get mod description
    */
   public final String getModDescription() {
     return modDescription;
   }
-  
+
   /**
    * Get mod category
    */
   public Category getModCategory() {
     return category;
   }
-  
+
   /**
    * The main mod command
    */
   public Command getCommandStub() {
     return stubCommand;
   }
-  
+
   /**
    * Check if mod is currently registered
    */
   public final boolean isRegistered() {
     return registered;
   }
-  
+
   /**
    * Register event to forge bus
    */
@@ -144,7 +152,7 @@ public abstract class BaseMod implements Globals {
       return false;
     }
   }
-  
+
   /**
    * Unregister event on forge bus
    */
@@ -157,11 +165,11 @@ public abstract class BaseMod implements Globals {
       return false;
     }
   }
-  
+
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder;
   }
-  
+
   @SuppressWarnings("unchecked")
   public final <T extends Command> T getCommand(String commandName) {
     try {
@@ -170,11 +178,11 @@ public abstract class BaseMod implements Globals {
       return null;
     }
   }
-  
+
   public final Setting<?> getSetting(String settingName) {
     return getCommand(settingName);
   }
-  
+
   public final Collection<Command> getCommands() {
     if (stubCommand != null) {
       return stubCommand.getChildren();
@@ -182,17 +190,17 @@ public abstract class BaseMod implements Globals {
       return Collections.emptyList();
     }
   }
-  
+
   /**
    * Check if the mod is hidden DEFAULT: true
    */
   public abstract boolean isHidden();
-  
+
   /**
    * Check if the mod is enabled
    */
   public abstract boolean isEnabled();
-  
+
   private void writeChildren(
       StringBuilder builder, Command command, final boolean deep, final String append) {
     command
@@ -212,7 +220,7 @@ public abstract class BaseMod implements Globals {
               }
             });
   }
-  
+
   protected void onProcessCommand(ExecuteData data) {
     if (data.getArgumentCount() == 0 && !data.options().hasOptions()) {
       final StringBuilder builder = new StringBuilder();
@@ -220,45 +228,45 @@ public abstract class BaseMod implements Globals {
       data.write(builder.toString());
     }
   }
-  
+
   /**
    * Called when the mod is loaded
    */
   protected abstract void onLoad();
-  
+
   /**
    * Called when unloaded
    */
   protected abstract void onUnload();
-  
+
   /**
    * Called when the mod is enabled
    */
   protected abstract void onEnabled();
-  
+
   /**
    * Called when the mod is disabled
    */
   protected abstract void onDisabled();
-  
+
   /**
    * Called when the bind is initially pressed
    */
   protected abstract void onBindPressed(CallbackData cb);
-  
+
   /**
    * Called while the bind key is pressed down
    */
   protected abstract void onBindKeyDown(CallbackData cb);
-  
+
   public String getDisplayText() {
     return getModName();
   }
-  
+
   public String getDebugDisplayText() {
     return getDisplayText();
   }
-  
+
   @Override
   public String toString() {
     return getModName() + ": " + getModDescription();

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -7,6 +7,7 @@ import com.matt.forgehax.util.command.callbacks.CallbackData;
 public class ToggleMod extends BaseMod {
   
   private final Setting<Boolean> enabled;
+  private final Setting<Boolean> hidden;
   
   public ToggleMod(Category category, String modName, boolean defaultValue, String description) {
     super(category, modName, description);
@@ -16,6 +17,27 @@ public class ToggleMod extends BaseMod {
             .<Boolean>newSettingBuilder()
             .name("enabled")
             .description("Enables the mod")
+            .defaultTo(defaultValue)
+            .changed(
+                cb -> { // value is set after callback is ran 🤡
+                  // do not call anything that might infinitely call this callback
+                  if (cb.getTo()) {
+                    start();
+                  } else {
+                    stop();
+                  }
+                })
+            .build();
+  }
+  
+  public HideMod(Category category, String modName, boolean defaultValue, String description) {
+    super(category, modName, description);
+    this.hidden =
+        getCommandStub()
+            .builders()
+            .<Boolean>newSettingBuilder()
+            .name("hidden")
+            .description("Hides the mod from modlist")
             .defaultTo(defaultValue)
             .changed(
                 cb -> { // value is set after callback is ran 🤡
@@ -50,6 +72,27 @@ public class ToggleMod extends BaseMod {
     enabled.set(false);
   }
   
+  /**
+   * Toggle mod to be displayed or not
+   */
+  public final void toggle() {
+    if (isHidden()) {
+      hide();
+    } else {
+      show();
+    }
+  }
+  
+  @Override
+  public void hide() {
+    hidden.set(true);
+  }
+  
+  @Override
+  public void show() {
+    hidden.set(false);
+  }
+  
   @Override
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder.kpressed(this::onBindPressed).kdown(this::onBindKeyDown).bind();
@@ -59,10 +102,14 @@ public class ToggleMod extends BaseMod {
   public String getDebugDisplayText() {
     return super.getDebugDisplayText();
   }
+ 
+  /**
+   * Check if the mod is currently shown
+   */
   
   @Override
   public boolean isHidden() {
-    return false;
+    return hidden.get();
   }
   
   /**

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -5,10 +5,10 @@ import com.matt.forgehax.util.command.StubBuilder;
 import com.matt.forgehax.util.command.callbacks.CallbackData;
 
 public class ToggleMod extends BaseMod {
-
+  
   private final Setting<Boolean> enabled;
   private final Setting<Boolean> hidden;
-
+  
   public ToggleMod(Category category, String modName, boolean defaultValue, String description) {
     super(category, modName, description);
     this.enabled =
@@ -45,7 +45,7 @@ public class ToggleMod extends BaseMod {
                 })
             .build();
   }
-
+  
   /**
    * Toggle mod to be on/off
    */
@@ -56,17 +56,17 @@ public class ToggleMod extends BaseMod {
       enable();
     }
   }
-
+  
   @Override
   public void enable() {
     enabled.set(true);
   }
-
+  
   @Override
   public void disable() {
     enabled.set(false);
   }
-
+  
   /**
    * Toggle mod to be displayed or not
    */
@@ -77,36 +77,36 @@ public class ToggleMod extends BaseMod {
       show();
     }
   }
-
+  
   @Override
   public void hide() {
     hidden.set(true);
   }
-
+  
   @Override
   public void show() {
     hidden.set(false);
   }
-
+  
   @Override
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder.kpressed(this::onBindPressed).kdown(this::onBindKeyDown).bind();
   }
-
+  
   @Override
   public String getDebugDisplayText() {
     return super.getDebugDisplayText();
   }
-
+  
   /**
    * Check if the mod is currently shown
    */
-
+  
   @Override
   public boolean isHidden() {
     return hidden.get();
   }
-
+  
   /**
    * Check if the mod is currently enabled
    */
@@ -114,23 +114,23 @@ public class ToggleMod extends BaseMod {
   public final boolean isEnabled() {
     return enabled.get();
   }
-
+  
   @Override
   protected void onLoad() {
   }
-
+  
   @Override
   protected void onUnload() {
   }
-
+  
   @Override
   protected void onEnabled() {
   }
-
+  
   @Override
   protected void onDisabled() {
   }
-
+  
   /**
    * Toggles the mod
    */
@@ -138,7 +138,7 @@ public class ToggleMod extends BaseMod {
   public void onBindPressed(CallbackData cb) {
     toggle();
   }
-
+  
   @Override
   protected void onBindKeyDown(CallbackData cb) {
   }

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -5,10 +5,10 @@ import com.matt.forgehax.util.command.StubBuilder;
 import com.matt.forgehax.util.command.callbacks.CallbackData;
 
 public class ToggleMod extends BaseMod {
-  
+
   private final Setting<Boolean> enabled;
   private final Setting<Boolean> hidden;
-  
+
   public ToggleMod(Category category, String modName, boolean defaultValue, String description) {
     super(category, modName, description);
     this.enabled =
@@ -28,10 +28,6 @@ public class ToggleMod extends BaseMod {
                   }
                 })
             .build();
-  }
-  
-  public HideMod(Category category, String modName, boolean defaultValue, String description) {
-    super(category, modName, description);
     this.hidden =
         getCommandStub()
             .builders()
@@ -40,8 +36,7 @@ public class ToggleMod extends BaseMod {
             .description("Hides the mod from modlist")
             .defaultTo(defaultValue)
             .changed(
-                cb -> { // value is set after callback is ran 🤡
-                  // do not call anything that might infinitely call this callback
+                cb -> {
                   if (cb.getTo()) {
                     start();
                   } else {
@@ -50,7 +45,7 @@ public class ToggleMod extends BaseMod {
                 })
             .build();
   }
-  
+
   /**
    * Toggle mod to be on/off
    */
@@ -61,57 +56,57 @@ public class ToggleMod extends BaseMod {
       enable();
     }
   }
-  
+
   @Override
   public void enable() {
     enabled.set(true);
   }
-  
+
   @Override
   public void disable() {
     enabled.set(false);
   }
-  
+
   /**
    * Toggle mod to be displayed or not
    */
-  public final void toggle() {
+  public final void display() {
     if (isHidden()) {
       hide();
     } else {
       show();
     }
   }
-  
+
   @Override
   public void hide() {
     hidden.set(true);
   }
-  
+
   @Override
   public void show() {
     hidden.set(false);
   }
-  
+
   @Override
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder.kpressed(this::onBindPressed).kdown(this::onBindKeyDown).bind();
   }
-  
+
   @Override
   public String getDebugDisplayText() {
     return super.getDebugDisplayText();
   }
- 
+
   /**
    * Check if the mod is currently shown
    */
-  
+
   @Override
   public boolean isHidden() {
     return hidden.get();
   }
-  
+
   /**
    * Check if the mod is currently enabled
    */
@@ -119,23 +114,23 @@ public class ToggleMod extends BaseMod {
   public final boolean isEnabled() {
     return enabled.get();
   }
-  
+
   @Override
   protected void onLoad() {
   }
-  
+
   @Override
   protected void onUnload() {
   }
-  
+
   @Override
   protected void onEnabled() {
   }
-  
+
   @Override
   protected void onDisabled() {
   }
-  
+
   /**
    * Toggles the mod
    */
@@ -143,7 +138,7 @@ public class ToggleMod extends BaseMod {
   public void onBindPressed(CallbackData cb) {
     toggle();
   }
-  
+
   @Override
   protected void onBindKeyDown(CallbackData cb) {
   }


### PR DESCRIPTION
I added in BaseMod the `hide()` and `show()` methods, but they just return (I guess by default a mod should not be hideable, only those toggleable should). In ToggleMod, those are Overridden and flip the `hidden` attribute (which just always returned `False`)

Many useless commits, sorry, squash freely