### PR TITLE
Reordered ClickGUI, added InfoDisplay, added basic ElytraFly modes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-forgehax.version=2.9.0
+forgehax.version=2.9.1
 forgehax.mc.version=1.12.2
 forgehax.forge.version=1.12.2-14.23.5.2846
 forgehax.mcp.version=1.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-forgehax.version=2.9.1
+forgehax.version=2.10.0
 forgehax.mc.version=1.12.2
 forgehax.forge.version=1.12.2-14.23.5.2846
 forgehax.mcp.version=1.12

--- a/src/main/java/com/matt/forgehax/gui/ClickGui.java
+++ b/src/main/java/com/matt/forgehax/gui/ClickGui.java
@@ -30,6 +30,7 @@ public class ClickGui extends GuiScreen implements Globals {
   private GuiWindowMod worldWindow = new GuiWindowMod(Category.WORLD);
   private GuiWindowMod miscWindow = new GuiWindowMod(Category.MISC);
   private GuiWindowMod chatWindow = new GuiWindowMod(Category.CHAT);
+  private final GuiWindowMod guiWindow = new GuiWindowMod(Category.GUI);
   
   {
     windowList.add(combatWindow);
@@ -39,6 +40,7 @@ public class ClickGui extends GuiScreen implements Globals {
     windowList.add(worldWindow);
     windowList.add(miscWindow);
     windowList.add(chatWindow);
+    windowList.add(guiWindow);
   }
   
   public static ScaledResolution scaledRes = new ScaledResolution(MC);

--- a/src/main/java/com/matt/forgehax/gui/ClickGui.java
+++ b/src/main/java/com/matt/forgehax/gui/ClickGui.java
@@ -24,17 +24,21 @@ public class ClickGui extends GuiScreen implements Globals {
   public final List<GuiWindow> windowList = new ArrayList<>();
   
   private GuiWindowMod combatWindow = new GuiWindowMod(Category.COMBAT);
+  private GuiWindowMod movementWindow = new GuiWindowMod(Category.MOVEMENT);
   private GuiWindowMod playerWindow = new GuiWindowMod(Category.PLAYER);
   private GuiWindowMod renderWindow = new GuiWindowMod(Category.RENDER);
   private GuiWindowMod worldWindow = new GuiWindowMod(Category.WORLD);
   private GuiWindowMod miscWindow = new GuiWindowMod(Category.MISC);
+  private GuiWindowMod chatWindow = new GuiWindowMod(Category.CHAT);
   
   {
     windowList.add(combatWindow);
+    windowList.add(movementWindow);
     windowList.add(playerWindow);
     windowList.add(renderWindow);
     windowList.add(worldWindow);
     windowList.add(miscWindow);
+    windowList.add(chatWindow);
   }
   
   public static ScaledResolution scaledRes = new ScaledResolution(MC);

--- a/src/main/java/com/matt/forgehax/mods/ActiveModList.java
+++ b/src/main/java/com/matt/forgehax/mods/ActiveModList.java
@@ -59,6 +59,15 @@ public class ActiveModList extends HudMod {
           .description("Shows lag time since last tick")
           .defaultTo(true)
           .build();
+
+  private final Setting<Boolean> condense =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("condense")
+          .description("Condense ModList when chat is open")
+          .defaultTo(true)
+          .build();
   
   private final Setting<SortMode> sortMode =
       getCommandStub()
@@ -139,7 +148,7 @@ public class ActiveModList extends HudMod {
       text.add(generateTickRateText());
     }
     
-    if (MC.currentScreen instanceof GuiChat || MC.gameSettings.showDebugInfo) {
+    if ((condense.get() && MC.currentScreen instanceof GuiChat) || MC.gameSettings.showDebugInfo) {
       long enabledMods = getModManager()
           .getMods()
           .stream()

--- a/src/main/java/com/matt/forgehax/mods/ActiveModList.java
+++ b/src/main/java/com/matt/forgehax/mods/ActiveModList.java
@@ -22,15 +22,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 @RegisterMod
 public class ActiveModList extends HudMod {
   
-  private final Setting<Boolean> tps_meter =
-      getCommandStub()
-          .builders()
-          .<Boolean>newSettingBuilder()
-          .name("tps-meter")
-          .description("Shows the server tps")
-          .defaultTo(true)
-          .build();
-  
   private final Setting<Boolean> debug =
       getCommandStub()
           .builders()
@@ -96,57 +87,11 @@ public class ActiveModList extends HudMod {
     return true;
   }
   
-  private String generateTickRateText() {
-    StringBuilder builder = new StringBuilder("Tick-rate: ");
-    TickRateService.TickRateData data = TickRateService.getTickData();
-    if (data.getSampleSize() <= 0) {
-      builder.append("No tick data");
-    } else {
-      int factor = this.factor.get();
-      int sections = data.getSampleSize() / factor;
-      if ((sections * factor) < data.getSampleSize()) {
-        TickRateService.TickRateData.CalculationData point = data.getPoint();
-        builder.append(String.format("%.2f", point.getAverage()));
-        builder.append(" (");
-        builder.append(data.getSampleSize());
-        builder.append(")");
-        if (sections > 0) builder.append(", ");
-      }
-      if (sections > 0) {
-        for (int i = sections; i > 0; i--) {
-          int at = i * factor;
-          TickRateService.TickRateData.CalculationData point = data.getPoint(at);
-          builder.append(String.format("%.2f", point.getAverage()));
-          builder.append(" (");
-          builder.append(at);
-          builder.append(")");
-          if ((i - 1) != 0) builder.append(", ");
-        }
-      }
-    }
-    
-    if (showLag.get()) {
-      long lastTickMs = TickRateService.getInstance().getLastTimeDiff();
-      
-      if (lastTickMs < 1000) {
-        builder.append(", 0.0s");
-      } else {
-        builder.append(String.format(", %01.1fs", ((float) (lastTickMs - 1000)) / 1000));
-      }
-    }
-    
-    return builder.toString();
-  }
-  
   @SubscribeEvent
   public void onRenderScreen(RenderGameOverlayEvent.Text event) {
     int align = alignment.get().ordinal();
     
     List<String> text = new ArrayList<>();
-    
-    if (tps_meter.get()) {
-      text.add(generateTickRateText());
-    }
     
     if ((condense.get() && MC.currentScreen instanceof GuiChat) || MC.gameSettings.showDebugInfo) {
       long enabledMods = getModManager()

--- a/src/main/java/com/matt/forgehax/mods/ActiveModList.java
+++ b/src/main/java/com/matt/forgehax/mods/ActiveModList.java
@@ -145,6 +145,7 @@ public class ActiveModList extends HudMod {
           .stream()
           .filter(BaseMod::isEnabled)
           .filter(mod -> !mod.isHidden())
+          .filter(mod -> !mod.notInList())
           .count();
       text.add(enabledMods + " mods enabled");
     } else {
@@ -153,6 +154,7 @@ public class ActiveModList extends HudMod {
           .stream()
           .filter(BaseMod::isEnabled)
           .filter(mod -> !mod.isHidden())
+          .filter(mod -> !mod.notInList())
           .map(mod -> debug.get() ? mod.getDebugDisplayText() : mod.getDisplayText())
           .sorted(sortMode.get().getComparator())
           .forEach(name -> text.add(AlignHelper.getFlowDirX2(align) == 1 ? ">" + name : name + "<"));

--- a/src/main/java/com/matt/forgehax/mods/AntiAfkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AntiAfkMod.java
@@ -112,7 +112,7 @@ public class AntiAfkMod extends ToggleMod {
   private TaskEnum task = TaskEnum.NONE;
   
   public AntiAfkMod() {
-    super(Category.PLAYER, "AntiAFK", false, "Swing arm to prevent being afk kicked");
+    super(Category.MISC, "AntiAFK", false, "Swing arm to prevent being afk kicked");
     
     TaskEnum.SWING.setParentSetting(swing);
     TaskEnum.WALK.setParentSetting(walk);

--- a/src/main/java/com/matt/forgehax/mods/AntiBatsMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AntiBatsMod.java
@@ -37,7 +37,7 @@ public class AntiBatsMod extends ToggleMod {
       };
   
   public AntiBatsMod() {
-    super(Category.RENDER, "AntiBats", false, "666 KILL BATS 666");
+    super(Category.WORLD, "AntiBats", false, "666 KILL BATS 666");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/AntiBatsMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AntiBatsMod.java
@@ -8,8 +8,10 @@ import com.matt.forgehax.util.entity.mobtypes.MobTypeRegistry;
 import com.matt.forgehax.util.mod.Category;
 import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
+import com.matt.forgehax.util.command.Setting;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.EntityBat;
+import net.minecraft.entity.passive.EntitySquid;
 import net.minecraft.init.SoundEvents;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.event.entity.PlaySoundAtEntityEvent;
@@ -17,7 +19,25 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @RegisterMod
 public class AntiBatsMod extends ToggleMod {
-  
+
+  private final Setting<Boolean> bats =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("bats")
+          .description("666 KILL BATS 666")
+          .defaultTo(true)
+          .build();
+
+  private final Setting<Boolean> squids =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("squids")
+          .description("<3 Phenom")
+          .defaultTo(true)
+          .build();
+
   private static final MobType BATS_MOBTYPE =
       new MobType() {
         @Override
@@ -35,37 +55,63 @@ public class AntiBatsMod extends ToggleMod {
           return MobTypeEnum.INVALID;
         }
       };
+
+  private static final MobType SQUIDS_MOBTYPE =
+      new MobType() {
+        @Override
+        protected PriorityEnum getPriority() {
+          return PriorityEnum.LOW;
+        }
+        
+        @Override
+        public boolean isMobType(Entity entity) {
+          return entity instanceof EntitySquid;
+        }
+        
+        @Override
+        protected MobTypeEnum getMobTypeUnchecked(Entity entity) {
+          return MobTypeEnum.INVALID;
+        }
+      };
   
   public AntiBatsMod() {
-    super(Category.WORLD, "AntiBats", false, "666 KILL BATS 666");
+    super(Category.WORLD, "AntiUselessMobs", false, "Disable useless passive mods");
   }
   
   @Override
   public void onEnabled() {
     MobTypeRegistry.register(BATS_MOBTYPE);
+    MobTypeRegistry.register(SQUIDS_MOBTYPE);
     EntityUtils.isBatsDisabled = true;
+    EntityUtils.isSquidsDisabled = true;
   }
   
   @Override
   public void onDisabled() {
     MobTypeRegistry.unregister(BATS_MOBTYPE);
+    MobTypeRegistry.unregister(SQUIDS_MOBTYPE);
     EntityUtils.isBatsDisabled = false;
+    EntityUtils.isSquidsDisabled = false;
   }
   
   @SubscribeEvent
   public void onRenderLiving(RenderLivingEvent.Pre<?> event) {
-    if (event.getEntity() instanceof EntityBat) {
+    if (bats.get() && event.getEntity() instanceof EntityBat) {
+      event.setCanceled(true);
+    }
+    if (squids.get() && event.getEntity() instanceof EntitySquid) {
       event.setCanceled(true);
     }
   }
   
   @SubscribeEvent
   public void onPlaySound(PlaySoundAtEntityEvent event) {
-    if (event.getSound().equals(SoundEvents.ENTITY_BAT_AMBIENT)
+    if (bats.get() && (
+		event.getSound().equals(SoundEvents.ENTITY_BAT_AMBIENT)
         || event.getSound().equals(SoundEvents.ENTITY_BAT_DEATH)
         || event.getSound().equals(SoundEvents.ENTITY_BAT_HURT)
         || event.getSound().equals(SoundEvents.ENTITY_BAT_LOOP)
-        || event.getSound().equals(SoundEvents.ENTITY_BAT_TAKEOFF)) {
+        || event.getSound().equals(SoundEvents.ENTITY_BAT_TAKEOFF))) {
       event.setVolume(0.f);
       event.setPitch(0.f);
       event.setCanceled(true);

--- a/src/main/java/com/matt/forgehax/mods/AntiFireMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AntiFireMod.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class AntiFireMod extends ToggleMod {
   
   public AntiFireMod() {
-    super(Category.PLAYER, "AntiFire", false, "Removes fire");
+    super(Category.WORLD, "AntiFire", false, "Removes fire");
   }
   
   private final Setting<Boolean> collisions =

--- a/src/main/java/com/matt/forgehax/mods/AutoBucketFallMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoBucketFallMod.java
@@ -29,7 +29,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 public class AutoBucketFallMod extends ToggleMod {
   
   public AutoBucketFallMod() {
-    super(Category.PLAYER, "AutoBucket", false, "Automatically place bucket to reset fall damage");
+    super(Category.MOVEMENT, "AutoBucket", false, "Automatically place bucket to reset fall damage");
   }
   
   public final Setting<Double> preHeight =

--- a/src/main/java/com/matt/forgehax/mods/AutoElytra.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoElytra.java
@@ -9,6 +9,6 @@ import com.matt.forgehax.util.mod.ToggleMod;
 public class AutoElytra extends ToggleMod {
   
   public AutoElytra() {
-    super(Category.PLAYER, "AutoElytra", false, "Automatically deploy elytra");
+    super(Category.MOVEMENT, "AutoElytra", false, "Automatically deploy elytra");
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/AutoHotbarReplenish.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoHotbarReplenish.java
@@ -68,7 +68,7 @@ public class AutoHotbarReplenish extends ToggleMod {
   
   public AutoHotbarReplenish() {
     super(
-        Category.PLAYER,
+        Category.COMBAT,
         "AutoHotbarReplenish",
         false,
         "Will replenish tools or block stacks automatically");

--- a/src/main/java/com/matt/forgehax/mods/AutoHotbarReplenish.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoHotbarReplenish.java
@@ -69,9 +69,9 @@ public class AutoHotbarReplenish extends ToggleMod {
   public AutoHotbarReplenish() {
     super(
         Category.COMBAT,
-        "AutoHotbarReplenish",
+        "AutoReplenish",
         false,
-        "Will replenish tools or block stacks automatically");
+        "Replenish tools or block stacks in your hotbar");
   }
   
   private boolean processing(int index) {

--- a/src/main/java/com/matt/forgehax/mods/AutoReply.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoReply.java
@@ -41,7 +41,7 @@ public class AutoReply extends ToggleMod {
           .build();
   
   public AutoReply() {
-    super(Category.MISC, "AutoReply", false, "Automatically talk in chat if finds a strings");
+    super(Category.CHAT, "AutoReply", false, "Automatically talk in chat if finds a strings");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/AutoRespawnMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoRespawnMod.java
@@ -18,7 +18,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
 public class AutoRespawnMod extends ToggleMod {
   
   public AutoRespawnMod() {
-    super(Category.PLAYER, "AutoRespawn", false, "Auto respawn on death");
+    super(Category.MISC, "AutoRespawn", false, "Auto respawn on death");
   }
   
   private final Setting<Integer> delay =

--- a/src/main/java/com/matt/forgehax/mods/AutoSprintMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoSprintMod.java
@@ -30,7 +30,7 @@ public class AutoSprintMod extends ToggleMod {
           .build();
   
   public AutoSprintMod() {
-    super(Category.PLAYER, "AutoSprint", false, "Automatically sprints");
+    super(Category.MOVEMENT, "AutoSprint", false, "Automatically sprints");
   }
   
   private void startSprinting() {

--- a/src/main/java/com/matt/forgehax/mods/AutoWalkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/AutoWalkMod.java
@@ -26,7 +26,7 @@ public class AutoWalkMod extends ToggleMod {
   private boolean isBound = false;
   
   public AutoWalkMod() {
-    super(Category.PLAYER, "AutoWalk", false, "Automatically walks forward");
+    super(Category.MOVEMENT, "AutoWalk", false, "Automatically walks forward");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/BedModeMod.java
+++ b/src/main/java/com/matt/forgehax/mods/BedModeMod.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class BedModeMod extends ToggleMod {
   
   public BedModeMod() {
-    super(Category.PLAYER, "BedMode", false, "Sleep walking");
+    super(Category.MISC, "BedMode", false, "Sleep walking");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/BoatFly.java
+++ b/src/main/java/com/matt/forgehax/mods/BoatFly.java
@@ -64,7 +64,7 @@ public class BoatFly extends ToggleMod {
           .build();
   
   public BoatFly() {
-    super(Category.MISC, "BoatFly", false, "Boathax");
+    super(Category.MOVEMENT, "BoatFly", false, "Boathax");
   }
   
   @SubscribeEvent // disable gravity

--- a/src/main/java/com/matt/forgehax/mods/ChatBot.java
+++ b/src/main/java/com/matt/forgehax/mods/ChatBot.java
@@ -65,7 +65,7 @@ public class ChatBot extends ToggleMod {
           .build();
   
   public ChatBot() {
-    super(Category.MISC, "ChatBot", false, "Spam chat");
+    super(Category.CHAT, "ChatBot", false, "Spam chat");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/ChatFilterMod.java
+++ b/src/main/java/com/matt/forgehax/mods/ChatFilterMod.java
@@ -34,7 +34,7 @@ public class ChatFilterMod extends ToggleMod {
           .build();
 
   public ChatFilterMod() {
-    super(Category.MISC, "ChatFilter", false, "Filter chat by regex");
+    super(Category.CHAT, "ChatFilter", false, "Filter chat by regex");
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/ChatFilterMod.java
+++ b/src/main/java/com/matt/forgehax/mods/ChatFilterMod.java
@@ -37,6 +37,13 @@ public class ChatFilterMod extends ToggleMod {
     super(Category.CHAT, "ChatFilter", false, "Filter chat by regex");
   }
 
+  private int filtered = 0;
+
+  @Override
+  public String getDisplayText() {
+    return (getModName() + " [" + filtered + "]");
+  }
+
   @SubscribeEvent
   public void onChatMessage(PacketEvent.Incoming.Pre event) {
     if (event.getPacket() instanceof SPacketChat) {
@@ -50,6 +57,7 @@ public class ChatFilterMod extends ToggleMod {
 
       if (shouldFilter) {
         event.setCanceled(true);
+		filtered++;
       }
     }
   }

--- a/src/main/java/com/matt/forgehax/mods/ChatWatermark.java
+++ b/src/main/java/com/matt/forgehax/mods/ChatWatermark.java
@@ -1,0 +1,47 @@
+package com.matt.forgehax.mods;
+
+import static com.matt.forgehax.Helper.getNetworkManager;
+import static com.matt.forgehax.Helper.printError;
+
+import com.matt.forgehax.asm.events.PacketEvent;
+import com.matt.forgehax.util.PacketHelper;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.network.play.client.CPacketChatMessage;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+// THANKS BABBAJ I'M USING LOTTA STUFF FROM FANCYCHAT
+
+@RegisterMod
+public class ChatWatermark extends ToggleMod {
+
+  private final Setting<String> text =
+      getCommandStub()
+          .builders()
+          .<String>newSettingBuilder()
+          .name("text")
+          .description("Text to add at the end of messages")
+          .defaultTo(" | imagine using Closed Source clients")
+          .build();
+  
+  public ChatWatermark() {
+    super(Category.CHAT, "ChatWatermark", false, "Add text after your chat to be ever cringier");
+  }
+  
+  @SubscribeEvent
+  public void onPacketSent(PacketEvent.Outgoing.Pre event) {
+    if (event.getPacket() instanceof CPacketChatMessage
+        && !PacketHelper.isIgnored(event.getPacket())) {
+      
+      String inputMessage = ((CPacketChatMessage) event.getPacket()).getMessage();
+	  if (!inputMessage.startsWith("/")) {
+          CPacketChatMessage packet = new CPacketChatMessage(inputMessage + text.get());
+          PacketHelper.ignore(packet);
+          getNetworkManager().sendPacket(packet);
+          event.setCanceled(true);
+      }
+    }
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/ChunkLogger.java
+++ b/src/main/java/com/matt/forgehax/mods/ChunkLogger.java
@@ -31,7 +31,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class ChunkLogger extends ToggleMod {
   
   public ChunkLogger() {
-    super(Category.MISC, "ChunkLogger", false, "Show new chunks");
+    super(Category.WORLD, "ChunkLogger", false, "Show new chunks");
   }
   
   enum ShowChunkEnum {

--- a/src/main/java/com/matt/forgehax/mods/ClientChunkSize.java
+++ b/src/main/java/com/matt/forgehax/mods/ClientChunkSize.java
@@ -38,7 +38,7 @@ public class ClientChunkSize extends ToggleMod {
   private ChunkPos current = null;
   
   public ClientChunkSize() {
-    super(Category.MISC, "ClientChunkSize", false, "Shows the client-side chunk size in bytes");
+    super(Category.WORLD, "ClientChunkSize", false, "Shows the client-side chunk size in bytes");
   }
   
   private static String toFormattedBytes(long size) {

--- a/src/main/java/com/matt/forgehax/mods/CoordsFinder.java
+++ b/src/main/java/com/matt/forgehax/mods/CoordsFinder.java
@@ -98,7 +98,7 @@ public class CoordsFinder extends ToggleMod {
   private final SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss.SSS");
   
   public CoordsFinder() {
-    super(Category.MISC, "CoordsFinder", false,
+    super(Category.WORLD, "CoordsFinder", false,
         "Logs coordinates of lightning strikes and teleports");
   }
   

--- a/src/main/java/com/matt/forgehax/mods/ElytraFlight.java
+++ b/src/main/java/com/matt/forgehax/mods/ElytraFlight.java
@@ -5,7 +5,6 @@ import static com.matt.forgehax.Helper.getNetworkManager;
 import com.matt.forgehax.asm.events.PacketEvent;
 
 import com.matt.forgehax.events.LocalPlayerUpdateEvent;
-import com.matt.forgehax.events.PlayerTravelEvent;
 import com.matt.forgehax.util.Switch.Handle;
 import com.matt.forgehax.util.command.Setting;
 import com.matt.forgehax.util.entity.LocalPlayerUtils;

--- a/src/main/java/com/matt/forgehax/mods/ElytraFlight.java
+++ b/src/main/java/com/matt/forgehax/mods/ElytraFlight.java
@@ -2,6 +2,7 @@ package com.matt.forgehax.mods;
 
 import static com.matt.forgehax.Helper.getLocalPlayer;
 import static com.matt.forgehax.Helper.getNetworkManager;
+import com.matt.forgehax.asm.events.PacketEvent;
 
 import com.matt.forgehax.events.LocalPlayerUpdateEvent;
 import com.matt.forgehax.util.Switch.Handle;
@@ -10,8 +11,10 @@ import com.matt.forgehax.util.entity.LocalPlayerUtils;
 import com.matt.forgehax.util.mod.Category;
 import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.network.play.client.CPacketEntityAction;
 import net.minecraft.network.play.client.CPacketEntityAction.Action;
+import net.minecraft.network.play.server.SPacketEntityMetadata;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -27,14 +30,41 @@ public class ElytraFlight extends ToggleMod {
           .description("Start flying when enabled")
           .defaultTo(false)
           .build();
-  
+
   public final Setting<Double> speed =
       getCommandStub()
           .builders()
           .<Double>newSettingBuilder()
           .name("speed")
-          .description("Movement speed")
+          .description("Base or max flight speed")
           .defaultTo(0.05D)
+          .build();
+  
+  public final Setting<Double> up_speed =
+      getCommandStub()
+          .builders()
+          .<Double>newSettingBuilder()
+          .name("up_speed")
+          .description("To keep altitude")
+          .defaultTo(0.002D)
+          .build();
+
+  public final Setting<Double> down_speed =
+      getCommandStub()
+          .builders()
+          .<Double>newSettingBuilder()
+          .name("down_speed")
+          .description("Downward speed")
+          .defaultTo(0.1D)
+          .build();
+
+  public final Setting<String> mode =
+      getCommandStub()
+          .builders()
+          .<String>newSettingBuilder()
+          .name("mode")
+          .description("control, fly or packet")
+          .defaultTo("control")
           .build();
   
   private final Handle flying = LocalPlayerUtils.getFlySwitch().createHandle(getModName());
@@ -42,38 +72,116 @@ public class ElytraFlight extends ToggleMod {
   public ElytraFlight() {
     super(Category.MOVEMENT, "ElytraFlight", false, "Elytra Flight");
   }
+
+  @Override
+  public String getDisplayText() {
+    return (getModName() + " [" + mode.get() + "]");
+  }
   
   @Override
   protected void onEnabled() {
-    if (fly_on_enable.get()) {
-      MC.addScheduledTask(
-          () -> {
-            if (getLocalPlayer() != null && !getLocalPlayer().isElytraFlying()) {
-              getNetworkManager()
-                  .sendPacket(new CPacketEntityAction(getLocalPlayer(), Action.START_FALL_FLYING));
-            }
-          });
+	switch(mode.get()) {
+	  case "control":
+	  case "fly":
+    	if (fly_on_enable.get()) {
+    	  MC.addScheduledTask(
+    	      () -> {
+    	        if (getLocalPlayer() != null && !getLocalPlayer().isElytraFlying()) {
+    	          getNetworkManager()
+    	              .sendPacket(new CPacketEntityAction(getLocalPlayer(), Action.START_FALL_FLYING));
+    	        }
+    	      });
+		}
+		break;
+	  case "packet":
+		MC.player.capabilities.isFlying = true;
+        MC.player.capabilities.allowFlying = true;
+    	getLocalPlayer().capabilities.setFlySpeed(speed.getAsFloat());
+		break;
     }
   }
   
   @Override
   public void onDisabled() {
-    flying.disable();
-    // Are we still here?
-    if (getLocalPlayer() != null) {
-      // Ensure the player starts flying again.
-      getNetworkManager()
-          .sendPacket(new CPacketEntityAction(getLocalPlayer(), Action.START_FALL_FLYING));
+	switch(mode.get()) {
+	  case "control":
+    	if (getLocalPlayer().capabilities.isCreativeMode) return;
+    	getLocalPlayer().capabilities.isFlying = false;
+		break;
+	  case "fly":
+    	flying.disable();
+    	// Are we still here?
+    	if (getLocalPlayer() != null) {
+    	  // Ensure the player starts flying again.
+    	  getNetworkManager()
+    	      .sendPacket(new CPacketEntityAction(getLocalPlayer(), Action.START_FALL_FLYING));
+    	}
+		break;
+	  case "packet":
+		MC.player.capabilities.isFlying = false;
+        MC.player.capabilities.allowFlying = false;
+    	getNetworkManager()
+    	    .sendPacket(new CPacketEntityAction(getLocalPlayer(), Action.START_FALL_FLYING));
+		break;
+	}
+  }
+
+  @SubscribeEvent
+  public void onPacketInbound(PacketEvent.Incoming.Pre event) {
+    if (this.isEnabled() && mode.get().equals("packet") && 
+		event.getPacket() instanceof SPacketEntityMetadata) {
+      event.setCanceled(true);
     }
   }
   
   @SubscribeEvent
-  @SideOnly(Side.CLIENT)
   public void onLocalPlayerUpdate(LocalPlayerUpdateEvent event) {
-    // Enable our flight as soon as the player starts flying his elytra.
-    if (getLocalPlayer().isElytraFlying()) {
-      flying.enable();
-    }
-    getLocalPlayer().capabilities.setFlySpeed(speed.getAsFloat());
+	switch(mode.get()) {
+	  case "fly":
+    	// Enable our flight as soon as the player starts flying his elytra.
+    	if (getLocalPlayer().isElytraFlying()) {
+    	  flying.enable();
+    	}
+    	getLocalPlayer().capabilities.setFlySpeed(speed.getAsFloat());
+		break;
+	  case "packet":
+		getNetworkManager()
+    	    .sendPacket(new CPacketEntityAction(getLocalPlayer(), Action.START_FALL_FLYING));
+		MC.player.capabilities.isFlying = true;
+        MC.player.jumpMovementFactor = up_speed.getAsFloat();
+		if (!MC.gameSettings.keyBindForward.isKeyDown() && !MC.gameSettings.keyBindBack.isKeyDown())
+        	MC.player.setVelocity(0.0, 0.0, 0.0);
+		break;
+	  case "control":
+    	if (!getLocalPlayer().isElytraFlying()) return;
+    	  if(getLocalPlayer().isInWater()) {
+    	      getNetworkManager()
+				.sendPacket(new CPacketEntityAction(getLocalPlayer(),Action.START_FALL_FLYING));
+    	      return;
+    	  }
+    	  if(MC.gameSettings.keyBindJump.isKeyDown())
+    	    getLocalPlayer().motionY += up_speed.get();
+    	  else if(MC.gameSettings.keyBindSneak.isKeyDown())
+    	    getLocalPlayer().motionY -= down_speed.get();
+		  else
+    	    getLocalPlayer().motionY = 0;
+
+    	  if(MC.gameSettings.keyBindForward.isKeyDown()) {
+    	    float yaw = (float)Math
+    	            .toRadians(getLocalPlayer().rotationYaw);
+    	    getLocalPlayer().motionX -= MathHelper.sin(yaw) * 0.05F;
+    	    getLocalPlayer().motionZ += MathHelper.cos(yaw) * 0.05F;
+    	  } else if (MC.gameSettings.keyBindBack.isKeyDown()) {
+    	    float yaw = (float)Math
+    	            .toRadians(MC.player.rotationYaw);
+    	    getLocalPlayer().motionX += MathHelper.sin(yaw) * 0.05F;
+    	    getLocalPlayer().motionZ -= MathHelper.cos(yaw) * 0.05F;
+    	  }
+		  if (Math.abs(getLocalPlayer().motionZ) > speed.get())
+			getLocalPlayer().motionZ = Math.signum(getLocalPlayer().motionZ) * speed.get();
+		  if (Math.abs(getLocalPlayer().motionX) > speed.get())
+			getLocalPlayer().motionX = Math.signum(getLocalPlayer().motionX) * speed.get();
+		  break;
+	}
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/ElytraFlight.java
+++ b/src/main/java/com/matt/forgehax/mods/ElytraFlight.java
@@ -40,7 +40,7 @@ public class ElytraFlight extends ToggleMod {
   private final Handle flying = LocalPlayerUtils.getFlySwitch().createHandle(getModName());
   
   public ElytraFlight() {
-    super(Category.PLAYER, "ElytraFlight", false, "Elytra Flight");
+    super(Category.MOVEMENT, "ElytraFlight", false, "Elytra Flight");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/FancyChat.java
+++ b/src/main/java/com/matt/forgehax/mods/FancyChat.java
@@ -197,7 +197,7 @@ public class FancyChat extends ToggleMod {
           .build();
   
   public FancyChat() {
-    super(Category.MISC, "FancyChat", false, "meme text");
+    super(Category.CHAT, "FancyChat", false, "meme text");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/FlyMod.java
+++ b/src/main/java/com/matt/forgehax/mods/FlyMod.java
@@ -24,7 +24,7 @@ public class FlyMod extends ToggleMod {
   private boolean zoomies = true;
   
   public FlyMod() {
-    super(Category.PLAYER, "Fly", false, "Enables flying");
+    super(Category.MOVEMENT, "Fly", false, "Enables flying");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/HorseJump.java
+++ b/src/main/java/com/matt/forgehax/mods/HorseJump.java
@@ -12,7 +12,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class HorseJump extends ToggleMod {
   
   public HorseJump() {
-    super(Category.PLAYER, "HorseJump", false, "always max horse jump");
+    super(Category.MOVEMENT, "HorseJump", false, "always max horse jump");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/HorseStats.java
+++ b/src/main/java/com/matt/forgehax/mods/HorseStats.java
@@ -22,7 +22,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class HorseStats extends ToggleMod {
   
   public HorseStats() {
-    super(Category.PLAYER, "HorseStats", false, "Change the stats of your horse");
+    super(Category.MOVEMENT, "HorseStats", false, "Change the stats of your horse");
   }
   
   private final Setting<Double> jumpHeight =

--- a/src/main/java/com/matt/forgehax/mods/InfoDisplay.java
+++ b/src/main/java/com/matt/forgehax/mods/InfoDisplay.java
@@ -15,7 +15,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import java.util.*;
 
 import static com.matt.forgehax.Helper.getModManager;
-import static com.matt.forgehax.util.draw.SurfaceHelper.getTextHeight;
 
 /**
  * Created by OverFloyd

--- a/src/main/java/com/matt/forgehax/mods/InfoDisplay.java
+++ b/src/main/java/com/matt/forgehax/mods/InfoDisplay.java
@@ -1,0 +1,110 @@
+package com.matt.forgehax.mods;
+
+import com.matt.forgehax.util.color.Colors;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.draw.SurfaceHelper;
+import com.matt.forgehax.util.math.AlignHelper;
+import com.matt.forgehax.util.mod.BaseMod;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.HudMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.client.gui.GuiChat;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.*;
+
+import static com.matt.forgehax.Helper.getModManager;
+import static com.matt.forgehax.util.draw.SurfaceHelper.getTextHeight;
+
+/**
+ * Created by OverFloyd
+ * may 2020
+ */
+@RegisterMod
+public class InfoDisplay extends HudMod {
+
+  public InfoDisplay() {
+    super(Category.GUI, "InfoDisplay", false, "Shows various useful infos");
+  }
+
+  private final Setting<SortMode> sortMode =
+    getCommandStub()
+      .builders()
+      .<SortMode>newSettingEnumBuilder()
+      .name("sorting")
+      .description("Sorting mode")
+      .defaultTo(SortMode.LENGTH)
+      .build();
+
+  @Override
+  protected AlignHelper.Align getDefaultAlignment() {
+    return AlignHelper.Align.TOPLEFT;
+  }
+
+  @Override
+  protected int getDefaultOffsetX() { return 0; }
+
+  @Override
+  protected int getDefaultOffsetY() {
+    return 1;
+  }
+
+  @Override
+  protected double getDefaultScale() {
+    return 1d;
+  }
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return false;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  int posY;
+
+  @SubscribeEvent
+  public void onRenderScreen(RenderGameOverlayEvent.Text event) {
+    int align = alignment.get().ordinal();
+    List<String> text = new ArrayList<>();
+
+    // Prints all the "InfoDisplayElement" mods
+    getModManager()
+      .getMods()
+      .stream()
+      .filter(BaseMod::isEnabled)
+      .filter(BaseMod::isInfoDisplayElement)
+      .map(BaseMod::getInfoDisplayText)
+      .sorted(sortMode.get().getComparator())
+      .forEach(name -> text.add(AlignHelper.getFlowDirX2(align) == 1 ? ">" + name : name + "<"));
+
+    // Shift up when chat is open && alignment is at bottom
+    if (alignment.get().toString().startsWith("BOTTOM") && MC.currentScreen instanceof GuiChat) {
+      posY = getPosY(15);
+    } else {
+      posY = getPosY(0);
+    }
+
+    // Prints on screen
+    SurfaceHelper.drawTextAlign(text, getPosX(offsetX.get()),
+      getPosY(offsetY.get()),
+      Colors.WHITE.toBuffer(), scale.get(), true, align);
+  }
+
+  public enum SortMode {
+    ALPHABETICAL((o1, o2) -> 0), // mod list is already sorted alphabetically
+    LENGTH(Comparator.<String>comparingInt(SurfaceHelper::getTextWidth).reversed());
+
+    private final Comparator<String> comparator;
+
+    public Comparator<String> getComparator() {
+      return this.comparator;
+    }
+
+    SortMode(Comparator<String> comparatorIn) {
+      this.comparator = comparatorIn;
+    }
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/InfoDisplay.java
+++ b/src/main/java/com/matt/forgehax/mods/InfoDisplay.java
@@ -33,7 +33,7 @@ public class InfoDisplay extends HudMod {
       .builders()
       .<SortMode>newSettingEnumBuilder()
       .name("sorting")
-      .description("Sorting mode")
+      .description("alphabetical or length")
       .defaultTo(SortMode.LENGTH)
       .build();
 

--- a/src/main/java/com/matt/forgehax/mods/InstantMessage.java
+++ b/src/main/java/com/matt/forgehax/mods/InstantMessage.java
@@ -27,7 +27,7 @@ public class InstantMessage extends ToggleMod {
           .build();
   
   public InstantMessage() {
-    super(Category.MISC, "InstantMessage", false, "Send message as soon as you join");
+    super(Category.CHAT, "InstantMessage", false, "Send message as soon as you join");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/Jesus.java
+++ b/src/main/java/com/matt/forgehax/mods/Jesus.java
@@ -35,7 +35,7 @@ public class Jesus extends ToggleMod {
       new AxisAlignedBB(0.D, 0.D, 0.D, 1.D, 0.99D, 1.D);
   
   public Jesus() {
-    super(Category.PLAYER, "Jesus", false, "Walk on water");
+    super(Category.MOVEMENT, "Jesus", false, "Walk on water");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/JoinMessage.java
+++ b/src/main/java/com/matt/forgehax/mods/JoinMessage.java
@@ -134,7 +134,7 @@ public class JoinMessage extends ToggleMod {
   private final Map<UUID, AtomicLong> cooldowns = Maps.newConcurrentMap();
   
   public JoinMessage() {
-    super(Category.MISC, "JoinMessage", false, "Allows players to add custom join messages");
+    super(Category.CHAT, "JoinMessage", false, "Allows players to add custom join messages");
   }
   
   private void debugMessage(String str) {

--- a/src/main/java/com/matt/forgehax/mods/LogoutSpot.java
+++ b/src/main/java/com/matt/forgehax/mods/LogoutSpot.java
@@ -61,7 +61,7 @@ public class LogoutSpot extends ToggleMod {
   private final Set<LogoutPos> spots = Sets.newHashSet();
   
   public LogoutSpot() {
-    super(Category.RENDER, "LogoutSpot", false, "show where a player logs out");
+    super(Category.WORLD, "LogoutSpot", false, "show where a player logs out");
   }
   
   private void reset() {

--- a/src/main/java/com/matt/forgehax/mods/MapDownloader.java
+++ b/src/main/java/com/matt/forgehax/mods/MapDownloader.java
@@ -58,7 +58,7 @@ public class MapDownloader extends ToggleMod {
           .build();
 
   public MapDownloader() {
-    super(Category.MISC, "MapDownloader", false, "Saves map items as images");
+    super(Category.WORLD, "MapDownloader", false, "Saves map items as images");
   }
 
   @Override

--- a/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
+++ b/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
@@ -203,7 +203,7 @@ public class MatrixNotifications extends ToggleMod {
     EXECUTOR.submit(() -> {
       try {
         HttpResponse res = post(url, json);
-        if (res.getStatusLine().getStatusCode() != 200 || res.getStatusLine().getStatusCode() != 200) {
+        if (res.getStatusLine().getStatusCode() != 200 && res.getStatusLine().getStatusCode() != 204) {
           throw new Error("got response code " + res.getStatusLine().getStatusCode());
         }
       } catch (Throwable t) {

--- a/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
+++ b/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
@@ -94,7 +94,7 @@ public class MatrixNotifications extends ToggleMod {
           .builders()
           .<String>newSettingBuilder()
           .name("url")
-          .description("URL to the Matrix web hook")
+          .description("URL to the WebHook")
           .defaultTo("")
           .build();
   
@@ -113,7 +113,7 @@ public class MatrixNotifications extends ToggleMod {
           .<String>newSettingBuilder()
           .name("skin-server-url")
           .description("URL to the skin server. If left empty then no image will be used.")
-          .defaultTo("https://visage.surgeplay.com/face/160/")
+          .defaultTo("https://minotar.net/helm/")
           .build();
   
   private final Setting<Integer> queue_notify_pos =
@@ -151,9 +151,18 @@ public class MatrixNotifications extends ToggleMod {
           .description("Message when player moves in the queue")
           .defaultTo(true)
           .build();
+
+  private final Setting<String> provider =
+      getCommandStub()
+          .builders()
+          .<String>newSettingBuilder()
+          .name("provider")
+          .description("Either Matrix or Discord")
+          .defaultTo("Matrix")
+          .build();
   
   public MatrixNotifications() {
-    super(Category.MISC, "MatrixNotifications", false, "Matrix notifications");
+    super(Category.CHAT, "WebNotify", false, "Send notifications via WebHook. Either on Discord or Matrix");
   }
   
   private boolean joined = false;
@@ -194,7 +203,7 @@ public class MatrixNotifications extends ToggleMod {
     EXECUTOR.submit(() -> {
       try {
         HttpResponse res = post(url, json);
-        if (res.getStatusLine().getStatusCode() != 200) {
+        if (res.getStatusLine().getStatusCode() != 200 && res.getStatusLine().getStatusCode() != 200) {
           throw new Error("got response code " + res.getStatusLine().getStatusCode());
         }
       } catch (Throwable t) {
@@ -224,13 +233,22 @@ public class MatrixNotifications extends ToggleMod {
   
   private void notify(String message) {
     JsonObject object = new JsonObject();
-    object.addProperty("text", message);
-    object.addProperty("format", "plain");
-    object.addProperty("displayName", MC.getSession().getUsername());
+	if (provider.get().equals("Discord")) {
+    	object.addProperty("content", message);
+    	object.addProperty("username", MC.getSession().getUsername());
+	} else {
+    	object.addProperty("text", message);
+    	object.addProperty("format", "plain");
+    	object.addProperty("displayName", MC.getSession().getUsername());
+	}
     
     String id = getUriUuid();
     if (!skin_server_url.get().isEmpty() && id != null) {
-      object.addProperty("avatarUrl", skin_server_url.get() + id);
+	  if (provider.get().equals("Discord")) {
+        object.addProperty("avatar_url", skin_server_url.get() + id);
+	  } else {
+        object.addProperty("avatarUrl", skin_server_url.get() + id);
+	  }
     }
     
     postAsync(url.get(), object);

--- a/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
+++ b/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
@@ -133,6 +133,15 @@ public class MatrixNotifications extends ToggleMod {
           .description("Message on connected to server")
           .defaultTo(true)
           .build();
+
+  private final Setting<Boolean> relay_chat =
+      getCommandStub()
+          .builders()
+          .<Boolean>newSettingBuilder()
+          .name("relay_chat")
+          .description("Pass all chat messages to WebHook")
+          .defaultTo(false)
+          .build();
   
   private final Setting<Boolean> on_disconnected =
       getCommandStub()
@@ -332,7 +341,11 @@ public class MatrixNotifications extends ToggleMod {
   public void onPacketRecieve(PacketEvent.Incoming.Pre event) {
     if (event.getPacket() instanceof SPacketChat) {
       SPacketChat packet = event.getPacket();
-      if (packet.getType() == ChatType.SYSTEM) {
+	  if (relay_chat.get()) {
+        ITextComponent comp = packet.getChatComponent();
+        String text = comp.getUnformattedText();
+		notify(text);
+      } else if (packet.getType() == ChatType.SYSTEM) {
         ITextComponent comp = packet.getChatComponent();
         if (comp.getSiblings().size() >= 2) {
           String text = comp.getSiblings().get(0).getUnformattedText();

--- a/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
+++ b/src/main/java/com/matt/forgehax/mods/MatrixNotifications.java
@@ -203,7 +203,7 @@ public class MatrixNotifications extends ToggleMod {
     EXECUTOR.submit(() -> {
       try {
         HttpResponse res = post(url, json);
-        if (res.getStatusLine().getStatusCode() != 200 && res.getStatusLine().getStatusCode() != 200) {
+        if (res.getStatusLine().getStatusCode() != 200 || res.getStatusLine().getStatusCode() != 200) {
           throw new Error("got response code " + res.getStatusLine().getStatusCode());
         }
       } catch (Throwable t) {

--- a/src/main/java/com/matt/forgehax/mods/NoCaveCulling.java
+++ b/src/main/java/com/matt/forgehax/mods/NoCaveCulling.java
@@ -9,7 +9,7 @@ import com.matt.forgehax.util.mod.loader.RegisterMod;
 public class NoCaveCulling extends ToggleMod {
   
   public NoCaveCulling() {
-    super(Category.RENDER, "NoCaveCulling", false, "Disables mojangs dumb cave culling shit");
+    super(Category.WORLD, "NoCaveCulling", false, "Disables mojangs dumb cave culling shit");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/NoFallMod.java
+++ b/src/main/java/com/matt/forgehax/mods/NoFallMod.java
@@ -16,7 +16,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class NoFallMod extends ToggleMod {
   
   public NoFallMod() {
-    super(Category.PLAYER, "NoFall", false, "Prevents fall damage from being taken");
+    super(Category.MOVEMENT, "NoFall", false, "Prevents fall damage from being taken");
   }
   
   private float lastFallDistance = 0;

--- a/src/main/java/com/matt/forgehax/mods/NoRotate.java
+++ b/src/main/java/com/matt/forgehax/mods/NoRotate.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class NoRotate extends ToggleMod {
   
   public NoRotate() {
-    super(Category.PLAYER, "NoRotate", false,
+    super(Category.MISC, "NoRotate", false,
         "Prevent server from setting client viewangles");
   }
   

--- a/src/main/java/com/matt/forgehax/mods/NoSkylightUpdates.java
+++ b/src/main/java/com/matt/forgehax/mods/NoSkylightUpdates.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class NoSkylightUpdates extends ToggleMod {
   
   public NoSkylightUpdates() {
-    super(Category.RENDER, "NoSkylightUpdates", false, "Prevents skylight updates");
+    super(Category.WORLD, "NoSkylightUpdates", false, "Prevents skylight updates");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/NoSlowdown.java
+++ b/src/main/java/com/matt/forgehax/mods/NoSlowdown.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class NoSlowdown extends ToggleMod {
   
   public NoSlowdown() {
-    super(Category.PLAYER, "NoSlowDown", false, "Disables block slowdown");
+    super(Category.MOVEMENT, "NoSlowDown", false, "Disables block slowdown");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/NoSoundLagMod.java
+++ b/src/main/java/com/matt/forgehax/mods/NoSoundLagMod.java
@@ -25,7 +25,7 @@ public class NoSoundLagMod extends ToggleMod {
   );
   
   public NoSoundLagMod() {
-    super(Category.MISC, "NoSoundLag", false, "lag exploit fix");
+    super(Category.WORLD, "NoSoundLag", false, "lag exploit fix");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/NoclipMod.java
+++ b/src/main/java/com/matt/forgehax/mods/NoclipMod.java
@@ -13,7 +13,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class NoclipMod extends ToggleMod {
   
   public NoclipMod() {
-    super(Category.PLAYER, "Noclip", false, "Enables player noclip");
+    super(Category.MOVEMENT, "Noclip", false, "Enables player noclip");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/Nuker.java
+++ b/src/main/java/com/matt/forgehax/mods/Nuker.java
@@ -135,7 +135,7 @@ public class Nuker extends ToggleMod implements PositionRotationManager.Movement
           .build();
   
   public Nuker() {
-    super(Category.PLAYER, "Nuker", false, "Mine blocks around yourself");
+    super(Category.WORLD, "Nuker", false, "Mine blocks around yourself");
     this.bindSelect.setKeyConflictContext(BindingHelper.getEmptyKeyConflictContext());
     ClientRegistry.registerKeyBinding(this.bindSelect);
   }

--- a/src/main/java/com/matt/forgehax/mods/PortalGui.java
+++ b/src/main/java/com/matt/forgehax/mods/PortalGui.java
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class PortalGui extends ToggleMod {
   
   public PortalGui() {
-    super(Category.PLAYER, "PortalGui", false, "Guis work while in portals");
+    super(Category.MISC, "PortalGui", false, "Guis work while in portals");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/RegionBorder.java
+++ b/src/main/java/com/matt/forgehax/mods/RegionBorder.java
@@ -34,7 +34,7 @@ public class RegionBorder extends ToggleMod {
 
 
   public RegionBorder() {
-    super(Category.RENDER, "RegionBorder", false, "Shows a border in front of the edge of the region you are in.");
+    super(Category.WORLD, "RegionBorder", false, "Shows a border in front of the edge of the region you are in.");
   }
 
   /**

--- a/src/main/java/com/matt/forgehax/mods/RiderDesync.java
+++ b/src/main/java/com/matt/forgehax/mods/RiderDesync.java
@@ -28,7 +28,7 @@ public class RiderDesync extends ToggleMod {
   private boolean forceUpdate = false;
   
   public RiderDesync() {
-    super(Category.PLAYER, "RiderDesync", false, "For entity force dismounting");
+    super(Category.MOVEMENT, "RiderDesync", false, "For entity force dismounting");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/SafeWalkMod.java
+++ b/src/main/java/com/matt/forgehax/mods/SafeWalkMod.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 public class SafeWalkMod extends ToggleMod {
   
   public SafeWalkMod() {
-    super(Category.PLAYER, "SafeWalk", false, "Prevents you from falling off blocks");
+    super(Category.MOVEMENT, "SafeWalk", false, "Prevents you from falling off blocks");
   }
   
   private final Setting<Boolean> collisions =

--- a/src/main/java/com/matt/forgehax/mods/Scaffold.java
+++ b/src/main/java/com/matt/forgehax/mods/Scaffold.java
@@ -47,7 +47,7 @@ public class Scaffold extends ToggleMod implements PositionRotationManager.Movem
   private Angle previousAngles = Angle.ZERO;
   
   public Scaffold() {
-    super(Category.PLAYER, "Scaffold", false, "Place blocks under yourself");
+    super(Category.MOVEMENT, "Scaffold", false, "Place blocks under yourself");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/SchematicaPrinterBypass.java
+++ b/src/main/java/com/matt/forgehax/mods/SchematicaPrinterBypass.java
@@ -20,7 +20,7 @@ import static com.matt.forgehax.Helper.*;
 public class SchematicaPrinterBypass extends ToggleMod {
 
   public SchematicaPrinterBypass() {
-    super(Category.MISC, "PrinterBypass", false, "Set silent angles for schematica printer");
+    super(Category.PLAYER, "PrinterBypass", false, "Set silent angles for schematica printer");
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/SignTextMod.java
+++ b/src/main/java/com/matt/forgehax/mods/SignTextMod.java
@@ -21,7 +21,7 @@ import org.lwjgl.input.Mouse;
 public class SignTextMod extends ToggleMod {
   
   public SignTextMod() {
-    super(Category.MISC, "SignText", false, "get sign text");
+    super(Category.WORLD, "SignText", false, "Copy sign text on middleclick");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/StepMod.java
+++ b/src/main/java/com/matt/forgehax/mods/StepMod.java
@@ -62,7 +62,7 @@ public class StepMod extends ToggleMod {
           .build();
   
   public StepMod() {
-    super(Category.PLAYER, "Step", false, "Step up blocks");
+    super(Category.MOVEMENT, "Step", false, "Step up blocks");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/StopEntityUpdates.java
+++ b/src/main/java/com/matt/forgehax/mods/StopEntityUpdates.java
@@ -12,7 +12,7 @@ public class StopEntityUpdates extends ToggleMod {
   
   public StopEntityUpdates() {
     super(
-        Category.MISC,
+        Category.WORLD,
         "StopEntityUpdates",
         false,
         "Prevent entity metadata update packets from being processed");

--- a/src/main/java/com/matt/forgehax/mods/ThisModIsDedicatedToUfoCrossing.java
+++ b/src/main/java/com/matt/forgehax/mods/ThisModIsDedicatedToUfoCrossing.java
@@ -27,7 +27,7 @@ public class ThisModIsDedicatedToUfoCrossing extends ToggleMod {
           .build();
 
   public ThisModIsDedicatedToUfoCrossing() {
-    super(Category.MISC, "MessageNearby", false, "Automatically send a message to whoever comes into render distance");
+    super(Category.CHAT, "MessageNearby", false, "Automatically send a message to whoever comes into render distance");
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/ThisModIsDedicatedToUfoCrossing.java
+++ b/src/main/java/com/matt/forgehax/mods/ThisModIsDedicatedToUfoCrossing.java
@@ -27,7 +27,7 @@ public class ThisModIsDedicatedToUfoCrossing extends ToggleMod {
           .build();
 
   public ThisModIsDedicatedToUfoCrossing() {
-    super(Category.MISC, "ThisModIsDedicatedToUfoCrossing", false, "Automatically send a message to whoever comes into render distance");
+    super(Category.MISC, "MessageNearby", false, "Automatically send a message to whoever comes into render distance");
   }
 
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/TrajectoryMod.java
+++ b/src/main/java/com/matt/forgehax/mods/TrajectoryMod.java
@@ -20,7 +20,7 @@ import org.lwjgl.opengl.GL11;
 public class TrajectoryMod extends ToggleMod {
   
   public TrajectoryMod() {
-    super(Category.RENDER, "Trajectory", false, "Draws projectile trajectory");
+    super(Category.COMBAT, "Trajectory", false, "Draws projectile trajectory");
   }
   
   @SubscribeEvent

--- a/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
+++ b/src/main/java/com/matt/forgehax/mods/VanillaFlyMod.java
@@ -57,7 +57,7 @@ public class VanillaFlyMod extends ToggleMod {
           .build();
   
   public VanillaFlyMod() {
-    super(Category.PLAYER, "VanillaFly", false, "Fly like creative mode");
+    super(Category.MOVEMENT, "VanillaFly", false, "Fly like creative mode");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/XrayMod.java
+++ b/src/main/java/com/matt/forgehax/mods/XrayMod.java
@@ -38,7 +38,7 @@ public class XrayMod extends ToggleMod {
   private boolean previousForgeLightPipelineEnabled = false;
   
   public XrayMod() {
-    super(Category.WORLD, "Xray", false, "See blocks through walls");
+    super(Category.RENDER, "Xray", false, "See blocks through walls");
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/mods/YawLockMod.java
+++ b/src/main/java/com/matt/forgehax/mods/YawLockMod.java
@@ -40,7 +40,7 @@ public class YawLockMod extends ToggleMod
           .build();
   
   public YawLockMod() {
-    super(Category.PLAYER, "YawLock", false, "Locks yaw to prevent moving into walls");
+    super(Category.MOVEMENT, "YawLock", false, "Locks yaw to prevent moving into walls");
   }
   
   private float getYawDirection(float yaw) {

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/DamageValue.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/DamageValue.java
@@ -1,0 +1,65 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.item.ItemStack;
+
+@RegisterMod
+public class DamageValue extends ToggleMod {
+
+  public DamageValue() {
+    super(Category.GUI, "DamageValue", true, "Shows damage value in main or offhand");
+  }
+
+  public enum Modes {
+    MAINHAND,
+    OFFHAND,
+    BOTH
+  }
+
+  public final Setting<Modes> damageValueMode =
+    getCommandStub()
+      .builders()
+      .<Modes>newSettingEnumBuilder()
+      .name("mode")
+      .description("")
+      .defaultTo(Modes.MAINHAND)
+      .build();
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    StringBuilder builderDamage = new StringBuilder("Damage value: ");
+    ItemStack itemStackM = MC.player.getHeldItemMainhand();
+    ItemStack itemStackO = MC.player.getHeldItemOffhand();
+
+    switch (damageValueMode.get()){
+      case MAINHAND: {
+        builderDamage.append(String.format("%s", itemStackM.getMaxDamage() - itemStackM.getItemDamage()));
+        break;
+      }
+      case OFFHAND: {
+        builderDamage.append(String.format("[%s]", itemStackO.getMaxDamage() - itemStackO.getItemDamage()));
+        break;
+      }
+      case BOTH: {
+        builderDamage.append(String.format("%s [%s]", (itemStackM.getMaxDamage() - itemStackM.getItemDamage()),
+          (itemStackO.getMaxDamage() - itemStackO.getItemDamage())));
+        break;
+      }
+      default: {
+        builderDamage.append("INVALID");
+      }
+    }
+
+    return builderDamage.toString();
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/FPS.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/FPS.java
@@ -1,0 +1,26 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.client.Minecraft;
+
+@RegisterMod
+public class FPS extends ToggleMod {
+
+  public FPS() {
+    super(Category.GUI, "FPS", true, "Shows your current FPS");
+  }
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    return "FPS: " + String.format("%s", Minecraft.getDebugFPS());
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Latency.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Latency.java
@@ -1,0 +1,43 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+
+@RegisterMod
+public class Latency extends ToggleMod {
+
+  public Latency() {
+    super(Category.GUI, "Latency", true, "Shows your ping");
+  }
+
+  int ping;
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    return "Ping: " + String.format("%s ms", latencyCalc());
+  }
+
+  private int latencyCalc(){
+    if (MC.getConnection() == null) {
+      return 1;
+    } else if (MC.player == null) {
+      return -1;
+    } else {
+      try {
+
+        // Returns the player's ping
+        return ping = MC.getConnection().getPlayerInfo(MC.player.getUniqueID()).getResponseTime();
+      } catch (NullPointerException ignored) {
+      }
+      return -1;
+    }
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/LightLevel.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/LightLevel.java
@@ -1,0 +1,37 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.util.math.BlockPos;
+
+import static com.matt.forgehax.Helper.getLocalPlayer;
+
+@RegisterMod
+public class LightLevel extends ToggleMod {
+
+  public LightLevel() {
+    super(Category.GUI, "LightLevel", false,
+      "Shows the light level of the block you're currently standing on");
+  }
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    EntityPlayerSP player = getLocalPlayer();
+    double thisX = player.posX;
+    double thisY = player.posY;
+    double thisZ = player.posZ;
+
+    BlockPos position = new BlockPos(thisX, thisY ,thisZ);
+
+    return "Light: " + String.format("%s", MC.world.getLight(position));
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Saturation.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Saturation.java
@@ -1,0 +1,25 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+
+@RegisterMod
+public class Saturation extends ToggleMod {
+
+  public Saturation() {
+    super(Category.GUI, "Saturation", true, "Shows your saturation level");
+  }
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    return "Saturation: " + String.format("%.2f", MC.player.getFoodStats().getSaturationLevel());
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
@@ -98,7 +98,7 @@ public class Speedometer extends ToggleMod {
 
   public String getInfoDisplayText() {
     //if (!showSpeedPerTicks.getAsBoolean()) {
-	String format = ("%." + roundto.getString() + "f")
+	String format = ("%." + roundto.getString() + "f");
     return "Speed: " + String.format(format, calculateTimerSpeed()) + " " + speedUnit.get().getString();
     //} else return "Speed: " + calculateSpeedPerTicks(final int ticks) + " " + speedUnit.get().getString();
   }

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
@@ -82,8 +82,7 @@ public class Speedometer extends ToggleMod {
     final double diffPosZ = MC.player.posZ - MC.player.prevPosZ;
 
     final double sqrtVal = Math.pow(diffPosX, 2) + Math.pow(diffPosZ, 2);
-
-    return Math.round(((MathHelper.sqrt(sqrtVal) / currentTps) * speedUnit.get().getMultiplier()) * Math.pow(10, roundto.get())) / Math.pow(10, roundto.get());
+    return ((MathHelper.sqrt(sqrtVal) / currentTps) * speedUnit.get().getMultiplier());
   }
 
   /*private double calculateSpeedPerTicks(final int ticks) {
@@ -99,7 +98,8 @@ public class Speedometer extends ToggleMod {
 
   public String getInfoDisplayText() {
     //if (!showSpeedPerTicks.getAsBoolean()) {
-    return "Speed: " + calculateTimerSpeed() + " " + speedUnit.get().getString();
+	String format = ("%." + roundto.getString() + "f")
+    return "Speed: " + String.format(format, calculateTimerSpeed()) + " " + speedUnit.get().getString();
     //} else return "Speed: " + calculateSpeedPerTicks(final int ticks) + " " + speedUnit.get().getString();
   }
 

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
@@ -58,7 +58,7 @@ public class Speedometer extends ToggleMod {
     getCommandStub()
       .builders()
       .<Integer>newSettingBuilder()
-      .name("round-to")
+      .name("roundto")
       .description("How many digits after the comma")
       .defaultTo(1)
       .min(0)
@@ -98,7 +98,7 @@ public class Speedometer extends ToggleMod {
 
   public String getInfoDisplayText() {
     //if (!showSpeedPerTicks.getAsBoolean()) {
-	String format = ("%." + roundto.getString() + "f");
+	String format = ("%." + roundto.get() + "f");
     return "Speed: " + String.format(format, calculateTimerSpeed()) + " " + speedUnit.get().getString();
     //} else return "Speed: " + calculateSpeedPerTicks(final int ticks) + " " + speedUnit.get().getString();
   }

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Speedometer.java
@@ -1,0 +1,134 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.asm.reflection.FastReflection;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.util.math.MathHelper;
+
+@RegisterMod
+public class Speedometer extends ToggleMod {
+
+  public Speedometer() {
+    super(Category.GUI, "Speedometer", true, "Shows speed o' meter");
+    //tickQueue = new LinkedList<>();
+  }
+
+  /*private final Setting<Integer> showSpeedPerTicks =
+    getCommandStub()
+      .builders()
+      .<Integer>newSettingBuilder()
+      .name("speed-per-ticks")
+      .description("Shows the speed you had between these ticks")
+      .defaultTo(20)
+      .build();*/
+
+  public enum SpeedUnitTypes {
+    KMH("km/h", 3.6D),
+    MS("m/s", 1D);
+
+    private final String string;
+    private final double multiplier;
+
+    SpeedUnitTypes(final String string, final double multiplier) {
+      this.string = string;
+      this.multiplier = multiplier;
+    }
+
+    public String getString() {
+      return string;
+    }
+
+    public double getMultiplier() {
+      return multiplier;
+    }
+  }
+
+  public final Setting<SpeedUnitTypes> speedUnit =
+    getCommandStub()
+      .builders()
+      .<SpeedUnitTypes>newSettingEnumBuilder()
+      .name("unit")
+      .description("Choose between KM/H or M/S")
+      .defaultTo(SpeedUnitTypes.KMH)
+      .build();
+
+  public final Setting<Integer> roundto =
+    getCommandStub()
+      .builders()
+      .<Integer>newSettingBuilder()
+      .name("round-to")
+      .description("How many digits after the comma")
+      .defaultTo(1)
+      .min(0)
+      .build();
+
+  //private final LinkedList<SpeedPerTickElement> tickQueue;
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  private double calculateTimerSpeed() {
+    // Gets current tps via FastReflection timer
+    final float currentTps = FastReflection.Fields.Timer_tickLength.get(FastReflection.Fields.Minecraft_timer.get(MC)) / 1000.0f;
+
+    final double diffPosX = MC.player.posX - MC.player.prevPosX;
+    final double diffPosZ = MC.player.posZ - MC.player.prevPosZ;
+
+    final double sqrtVal = Math.pow(diffPosX, 2) + Math.pow(diffPosZ, 2);
+
+    return Math.round(((MathHelper.sqrt(sqrtVal) / currentTps) * speedUnit.get().getMultiplier()) * Math.pow(10, roundto.get())) / Math.pow(10, roundto.get());
+  }
+
+  /*private double calculateSpeedPerTicks(final int ticks) {
+    final SpeedPerTickElement newElement = new SpeedPerTickElement(MC.player.posX, MC.player.posZ);
+    tickQueue.add(newElement);
+    final double speed = newElement.calculateSpeed(tickQueue.getFirst(), speedUnit.get().getMultiplier(), roundto);
+
+    while (tickQueue.size() > ticks) { // a while so we dont stack up a lot of elements in the queue (shouldnt happen.. but who knows)
+      tickQueue.removeFirst();
+    }
+    return speed;
+  }*/
+
+  public String getInfoDisplayText() {
+    //if (!showSpeedPerTicks.getAsBoolean()) {
+    return "Speed: " + calculateTimerSpeed() + " " + speedUnit.get().getString();
+    //} else return "Speed: " + calculateSpeedPerTicks(final int ticks) + " " + speedUnit.get().getString();
+  }
+
+  private static class SpeedPerTickElement {
+    private final long time;
+    private final double x;
+    private final double z;
+
+    public SpeedPerTickElement(final double x, final double z) {
+      this.time = System.currentTimeMillis();
+      this.x = x;
+      this.z = z;
+    }
+
+    /**
+     * we request an element that got generated earlier so we dont care if the speed is negative... might have some use case?
+     * @param earlier the earlier element.
+     * @param multiplier constant for the speed unit.
+     * @param roundto how many digits after the comma.
+     * @return returns the speed.
+     */
+    public double calculateSpeed(final SpeedPerTickElement earlier, final double multiplier, final int roundto) {
+      final double deltaX = this.x - earlier.x;
+      final double deltaZ = this.z - earlier.z;
+      final long deltaTime = this.time - earlier.time;
+      if(deltaTime == 0) {
+        return 0;
+      }
+      return Math.round((MathHelper.sqrt(deltaX * deltaX + deltaZ * deltaZ) * multiplier * 1000D / deltaTime) * 10)/10;
+    }
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/SystemTime.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/SystemTime.java
@@ -1,0 +1,63 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@RegisterMod
+public class SystemTime extends ToggleMod {
+
+  public SystemTime() {
+    super(Category.GUI, "SystemTime", false, "Shows the time from your operating system");
+  }
+
+  private final Setting<Boolean> showTime =
+    getCommandStub()
+      .builders()
+      .<Boolean>newSettingBuilder()
+      .name("time")
+      .description("Show time")
+      .defaultTo(true)
+      .build();
+
+  private final Setting<Boolean> showDate =
+    getCommandStub()
+      .builders()
+      .<Boolean>newSettingBuilder()
+      .name("date")
+      .description("Show date")
+      .defaultTo(true)
+      .build();
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    StringBuilder builderTime = new StringBuilder();
+
+    if(showDate.getAsBoolean()) {
+      final String date = new SimpleDateFormat("dd/MM/yyyy").format(new Date());
+      builderTime.append(String.format("%s", date));
+    }
+
+    if (showTime.getAsBoolean()) {
+      if (showDate.getAsBoolean()) {
+        builderTime.append(", ");
+      }
+      
+      final String time = new SimpleDateFormat("HH:mm:ss").format(new Date());
+      builderTime.append(String.format("%s", time));
+    }
+
+    return builderTime.toString();
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/TickRate.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/TickRate.java
@@ -1,0 +1,115 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.mods.services.TickRateService;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+
+@RegisterMod
+public class TickRate extends ToggleMod {
+
+  public TickRate() {
+    super(Category.GUI, "TickRate", true, "Shows the server tick-rate data");
+  }
+
+  public enum tickRateModes {
+    TICKRATE,
+    TPS
+  }
+
+  public final Setting<tickRateModes> tickRateMode =
+    getCommandStub()
+      .builders()
+      .<tickRateModes>newSettingEnumBuilder()
+      .name("mode")
+      .description("Modes for tick-rate")
+      .defaultTo(tickRateModes.TICKRATE)
+      .build();
+
+  private final Setting<Integer> factor =
+    getCommandStub()
+      .builders()
+      .<Integer>newSettingBuilder()
+      .name("factor")
+      .description("Splitting up the tick rate data")
+      .defaultTo(25)
+      .min(25)
+      .max(100)
+      .build();
+
+  private final Setting<Boolean> showLag =
+    getCommandStub()
+      .builders()
+      .<Boolean>newSettingBuilder()
+      .name("lag")
+      .description("Shows lag time since last valid tick")
+      .defaultTo(true)
+      .build();
+
+  @Override
+  public boolean isInfoDisplayElement() {
+    return true;
+  }
+
+  /*@Override
+  public boolean isVisible() { return false; }*/
+
+  public String getInfoDisplayText() {
+    TickRateService.TickRateData data = TickRateService.getTickData();
+    StringBuilder builderTickRate = new StringBuilder();
+
+    if (tickRateMode.get() == tickRateModes.TICKRATE) {
+      builderTickRate.append("Tick-rate: ");
+
+      if (data.getSampleSize() <= 0) {
+        builderTickRate.append("No tick data");
+      } else {
+        int factor = this.factor.get();
+        int sections = data.getSampleSize() / factor;
+
+        if ((sections * factor) < data.getSampleSize()) {
+          TickRateService.TickRateData.CalculationData point = data.getPoint();
+          builderTickRate.append(String.format("%.2f", point.getAverage()));
+          builderTickRate.append(" (");
+          builderTickRate.append(data.getSampleSize());
+          builderTickRate.append(")");
+
+          if (sections > 0) builderTickRate.append(", ");
+        }
+
+        if (sections > 0) {
+          for (int i = sections; i > 0; i--) {
+            int at = i * factor;
+            TickRateService.TickRateData.CalculationData point = data.getPoint(at);
+            builderTickRate.append(String.format("%.2f", point.getAverage()));
+            builderTickRate.append(" (");
+            builderTickRate.append(at);
+            builderTickRate.append(")");
+            if ((i - 1) != 0) builderTickRate.append(", ");
+          }
+        }
+      }
+    } else if (tickRateMode.get() == tickRateModes.TPS) {
+      TickRateService.TickRateData.CalculationData point = data.getPoint();
+      builderTickRate.append(String.format("TPS: %.2f", point.getAverage()));
+    }
+
+    // Last tick function.
+    if (showLag.get()) {
+      float lastTickMs = TickRateService.getInstance().getLastTimeDiff();
+
+      if (lastTickMs < 1000) {
+
+        // Adds 0.0s to the StringBuilder.
+        builderTickRate.append(", 0.0s");
+      } else {
+
+        // Adds lag time in seconds since last tick.
+        builderTickRate.append(String.format(", %01.1fs", ((float) (lastTickMs - 1000)) / 1000));
+      }
+    }
+
+    return builderTickRate.toString();
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Watermark.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Watermark.java
@@ -5,6 +5,9 @@ import com.matt.forgehax.util.mod.Category;
 import com.matt.forgehax.util.mod.ToggleMod;
 import com.matt.forgehax.util.mod.loader.RegisterMod;
 import com.matt.forgehax.util.draw.SurfaceHelper;
+import com.matt.forgehax.util.color.Colors;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @RegisterMod
 public class Watermark extends ToggleMod {
@@ -16,25 +19,25 @@ public class Watermark extends ToggleMod {
   private final Setting<String> text =
     getCommandStub()
       .builders()
-      .<Boolean>newSettingBuilder()
+      .<String>newSettingBuilder()
       .name("text")
       .description("Watermark text")
-      .defaultTo("ForgeHax > all")
+      .defaultTo("ForgeHax 2.9.1")
       .build();
 
-  private final Setting<Double> x_offset =
+  private final Setting<Integer> x_offset =
     getCommandStub()
       .builders()
-      .<Double>newSettingBuilder()
+      .<Integer>newSettingBuilder()
       .name("x_offset")
       .description("Offset on x axis")
       .defaultTo(80)
       .build();
 
-  private final Setting<Double> y_offset =
+  private final Setting<Integer> y_offset =
     getCommandStub()
       .builders()
-      .<Double>newSettingBuilder()
+      .<Integer>newSettingBuilder()
       .name("y_offset")
       .description("Offset on y axis")
       .defaultTo(8)

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Watermark.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Watermark.java
@@ -10,7 +10,7 @@ import com.matt.forgehax.util.draw.SurfaceHelper;
 public class Watermark extends ToggleMod {
 
   public Watermark() {
-    super(Category.GUI, "Watermark", false, "Display a watermark on your screen");
+    super(Category.GUI, "Watermark", true, "Display a watermark on your screen");
   }
 
   private final Setting<String> text =
@@ -19,29 +19,29 @@ public class Watermark extends ToggleMod {
       .<Boolean>newSettingBuilder()
       .name("text")
       .description("Watermark text")
-      .defaultTo("ForgeHax On Top!")
+      .defaultTo("ForgeHax > all")
       .build();
 
-  private final Setting<Double> x-offset =
+  private final Setting<Double> x_offset =
     getCommandStub()
       .builders()
       .<Double>newSettingBuilder()
-      .name("x-offset")
+      .name("x_offset")
       .description("Offset on x axis")
       .defaultTo(80)
       .build();
 
-  private final Setting<Double> y-offset =
+  private final Setting<Double> y_offset =
     getCommandStub()
       .builders()
       .<Double>newSettingBuilder()
-      .name("y-offset")
+      .name("y_offset")
       .description("Offset on y axis")
       .defaultTo(8)
       .build();
 
   @SubscribeEvent
   public void onRenderScreen(RenderGameOverlayEvent.Text event) {
-    SurfaceHelper.drawText(text.get(), x-offset.get(), y-offset.get(), Colors.BETTER_PURPLE.toBuffer());
+    SurfaceHelper.drawText(text.get(), x_offset.get(), y_offset.get(), Colors.BETTER_PURPLE.toBuffer());
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/infooverlay/Watermark.java
+++ b/src/main/java/com/matt/forgehax/mods/infooverlay/Watermark.java
@@ -1,0 +1,47 @@
+package com.matt.forgehax.mods.infooverlay;
+
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import com.matt.forgehax.util.draw.SurfaceHelper;
+
+@RegisterMod
+public class Watermark extends ToggleMod {
+
+  public Watermark() {
+    super(Category.GUI, "Watermark", false, "Display a watermark on your screen");
+  }
+
+  private final Setting<String> text =
+    getCommandStub()
+      .builders()
+      .<Boolean>newSettingBuilder()
+      .name("text")
+      .description("Watermark text")
+      .defaultTo("ForgeHax On Top!")
+      .build();
+
+  private final Setting<Double> x-offset =
+    getCommandStub()
+      .builders()
+      .<Double>newSettingBuilder()
+      .name("x-offset")
+      .description("Offset on x axis")
+      .defaultTo(80)
+      .build();
+
+  private final Setting<Double> y-offset =
+    getCommandStub()
+      .builders()
+      .<Double>newSettingBuilder()
+      .name("y-offset")
+      .description("Offset on y axis")
+      .defaultTo(8)
+      .build();
+
+  @SubscribeEvent
+  public void onRenderScreen(RenderGameOverlayEvent.Text event) {
+    SurfaceHelper.drawText(text.get(), x-offset.get(), y-offset.get(), Colors.BETTER_PURPLE.toBuffer());
+  }
+}

--- a/src/main/java/com/matt/forgehax/util/color/Colors.java
+++ b/src/main/java/com/matt/forgehax/util/color/Colors.java
@@ -12,6 +12,7 @@ public interface Colors {
   Color BLUE = Color.of(0, 0, 255, 255);
   Color ORANGE = Color.of(255, 128, 0, 255);
   Color PURPLE = Color.of(163, 73, 163, 255);
+  Color BETTER_PURPLE = Color.of(141, 75, 163, 255);
   Color GRAY = Color.of(127, 127, 127, 255);
   Color DARK_RED = Color.of(64, 0, 0, 255);
   Color YELLOW = Color.of(255, 255, 0, 255);

--- a/src/main/java/com/matt/forgehax/util/entity/EntityUtils.java
+++ b/src/main/java/com/matt/forgehax/util/entity/EntityUtils.java
@@ -54,6 +54,7 @@ public class EntityUtils implements Globals {
   }
   
   public static boolean isBatsDisabled = false;
+  public static boolean isSquidsDisabled = false;
   
   /**
    * Checks if the mob could be possibly hostile towards us (we can't detect their attack target
@@ -128,6 +129,7 @@ public class EntityUtils implements Globals {
     return (entity.isCreatureType(EnumCreatureType.CREATURE, false)
         && !EntityUtils.isNeutralMob(entity))
         || (entity.isCreatureType(EnumCreatureType.AMBIENT, false) && !isBatsDisabled)
+		|| (entity.isCreatureType(EnumCreatureType.WATER_CREATURE, false) && !isSquidsDisabled)
         || entity instanceof EntityVillager
         || entity instanceof EntityIronGolem
         || (isNeutralMob(entity) && !EntityUtils.isMobAggressive(entity));

--- a/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
@@ -96,6 +96,12 @@ public abstract class BaseMod implements Globals {
   public void disable() {
     stop();
   }
+
+  public void hide() {
+  }
+  
+  public void show() {
+  }
   
   public void hide() {
     return;
@@ -201,7 +207,12 @@ public abstract class BaseMod implements Globals {
    * Hides a mod from the ModList
    */ 
   public abstract boolean notInList();
-  
+
+  /**
+   * Check if the mod is an element of InfoDisplay mod DEFAULT: true
+   */
+  public abstract boolean isInfoDisplayElement();
+
   /**
    * Check if the mod is enabled
    */
@@ -268,7 +279,11 @@ public abstract class BaseMod implements Globals {
   public String getDisplayText() {
     return getModName();
   }
-  
+
+  public String getInfoDisplayText() {
+    return getInfoDisplayText();
+  }
+
   public String getDebugDisplayText() {
     return getDisplayText();
   }

--- a/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
@@ -103,14 +103,6 @@ public abstract class BaseMod implements Globals {
   public void show() {
   }
   
-  public void hide() {
-    return;
-  }
-  
-  public void show() {
-    return;
-  }
-  
   /**
    * Get the categories name
    */

--- a/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/BaseMod.java
@@ -1,7 +1,7 @@
 package com.matt.forgehax.util.mod;
-
+  
 import static com.matt.forgehax.Helper.getGlobalCommand;
-
+  
 import com.matt.forgehax.Globals;
 import com.matt.forgehax.util.command.Command;
 import com.matt.forgehax.util.command.ExecuteData;
@@ -12,7 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import joptsimple.internal.Strings;
 import net.minecraftforge.common.MinecraftForge;
-
+  
 public abstract class BaseMod implements Globals {
   
   // name of the mod
@@ -95,6 +95,14 @@ public abstract class BaseMod implements Globals {
   
   public void disable() {
     stop();
+  }
+  
+  public void hide() {
+    return;
+  }
+  
+  public void show() {
+    return;
   }
   
   /**
@@ -187,6 +195,12 @@ public abstract class BaseMod implements Globals {
    * Check if the mod is hidden DEFAULT: true
    */
   public abstract boolean isHidden();
+
+
+  /**
+   * Hides a mod from the ModList
+   */ 
+  public abstract boolean notInList();
   
   /**
    * Check if the mod is enabled

--- a/src/main/java/com/matt/forgehax/util/mod/Category.java
+++ b/src/main/java/com/matt/forgehax/util/mod/Category.java
@@ -4,8 +4,7 @@ package com.matt.forgehax.util.mod;
  * Created on 9/4/2017 by fr1kin
  */
 public enum Category {
-  NONE("", ""),
-  MOVEMENT("Movement", ""),
+  NONE("N/A", "You should not see this"),
   COMBAT("Combat", "Combat related mods"),
   MOVEMENT("Movement", "Anything related to moving"),
   PLAYER("Player", "Mods that interact with the local player"),

--- a/src/main/java/com/matt/forgehax/util/mod/Category.java
+++ b/src/main/java/com/matt/forgehax/util/mod/Category.java
@@ -5,6 +5,7 @@ package com.matt.forgehax.util.mod;
  */
 public enum Category {
   NONE("", ""),
+  MOVEMENT("Movement", ""),
   COMBAT("Combat", "Combat related mods"),
   MOVEMENT("Movement", "Anything related to moving"),
   PLAYER("Player", "Mods that interact with the local player"),
@@ -12,11 +13,12 @@ public enum Category {
   WORLD("World", "Any mod that has to do with the world"),
   MISC("Misc", "Miscellaneous"),
   CHAT("Chat", "Mods related to chat"),
+  GUI("GUI", "User Interface modules"),
   SERVICE("Service", "Background mods"),
   ;
   
-  private String prettyName;
-  private String description;
+  private final String prettyName;
+  private final String description;
   
   Category(String prettyName, String description) {
     this.prettyName = prettyName;

--- a/src/main/java/com/matt/forgehax/util/mod/Category.java
+++ b/src/main/java/com/matt/forgehax/util/mod/Category.java
@@ -6,10 +6,12 @@ package com.matt.forgehax.util.mod;
 public enum Category {
   NONE("", ""),
   COMBAT("Combat", "Combat related mods"),
+  MOVEMENT("Movement", "Anything related to moving"),
   PLAYER("Player", "Mods that interact with the local player"),
   RENDER("Render", "2D/3D rendering mods"),
   WORLD("World", "Any mod that has to do with the world"),
   MISC("Misc", "Miscellaneous"),
+  CHAT("Chat", "Mods related to chat"),
   SERVICE("Service", "Background mods"),
   ;
   

--- a/src/main/java/com/matt/forgehax/util/mod/HudMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/HudMod.java
@@ -60,6 +60,11 @@ public abstract class HudMod extends ToggleMod {
             .defaultTo(getDefaultScale())
             .build();
   }
+
+  @Override
+  public boolean notInList() {
+	return true;
+  }
   
   // no need to recalc each frame but okay (on GuiScale and Settings change only)
   public final int getPosX(int extraOffset) {

--- a/src/main/java/com/matt/forgehax/util/mod/ServiceMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ServiceMod.java
@@ -22,7 +22,7 @@ public class ServiceMod extends BaseMod {
 
   @Override
   public boolean notInList() {
-	return false;
+	return true;
   }
   
   @Override

--- a/src/main/java/com/matt/forgehax/util/mod/ServiceMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ServiceMod.java
@@ -19,6 +19,11 @@ public class ServiceMod extends BaseMod {
   public boolean isHidden() {
     return true;
   }
+
+  @Override
+  public boolean notInList() {
+	return false;
+  }
   
   @Override
   public boolean isEnabled() {

--- a/src/main/java/com/matt/forgehax/util/mod/ServiceMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ServiceMod.java
@@ -49,6 +49,11 @@ public class ServiceMod extends BaseMod {
   @Override
   protected void onBindPressed(CallbackData cb) {
   }
+
+  @Override
+  public boolean isInfoDisplayElement() {
+	return false;
+  }
   
   @Override
   protected void onBindKeyDown(CallbackData cb) {

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -7,6 +7,7 @@ import com.matt.forgehax.util.command.callbacks.CallbackData;
 public class ToggleMod extends BaseMod {
   
   private final Setting<Boolean> enabled;
+  private final Setting<Boolean> nolist;
   
   public ToggleMod(Category category, String modName, boolean defaultValue, String description) {
     super(category, modName, description);
@@ -20,6 +21,22 @@ public class ToggleMod extends BaseMod {
             .changed(
                 cb -> { // value is set after callback is ran 🤡
                   // do not call anything that might infinitely call this callback
+                  if (cb.getTo()) {
+                    start();
+                  } else {
+                    stop();
+                  }
+                })
+            .build();
+    this.nolist =
+        getCommandStub()
+            .builders()
+            .<Boolean>newSettingBuilder()
+            .name("hidden")
+            .description("Hides the mod from modlist")
+            .defaultTo(defaultValue)
+            .changed(
+                cb -> {
                   if (cb.getTo()) {
                     start();
                   } else {
@@ -50,6 +67,27 @@ public class ToggleMod extends BaseMod {
     enabled.set(false);
   }
   
+  /**
+   * Toggle mod to be displayed or not
+   */
+  public final void display() {
+    if (notInList()) {
+      hide();
+    } else {
+      show();
+    }
+  }
+  
+  @Override
+  public void hide() {
+    nolist.set(true);
+  }
+  
+  @Override
+  public void show() {
+    nolist.set(false);
+  }
+  
   @Override
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder.kpressed(this::onBindPressed).kdown(this::onBindKeyDown).bind();
@@ -59,12 +97,21 @@ public class ToggleMod extends BaseMod {
   public String getDebugDisplayText() {
     return super.getDebugDisplayText();
   }
+
+  /**
+   * Check if the mod is currently shown
+   */
   
   @Override
   public boolean isHidden() {
     return false;
   }
-  
+
+  @Override
+  public boolean notInList() {
+	return nolist.get();
+  }
+
   /**
    * Check if the mod is currently enabled
    */

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -66,6 +66,27 @@ public class ToggleMod extends BaseMod {
   public void disable() {
     enabled.set(false);
   }
+
+  /**
+   * Toggle mod to be displayed or not
+   */
+  public final void display() {
+    if (notInList()) {
+      hide();
+    } else {
+      show();
+    }
+  }
+  
+  @Override
+  public void hide() {
+    nolist.set(true);
+  }
+  
+  @Override
+  public void show() {
+    nolist.set(false);
+  }
   
   /**
    * Toggle mod to be displayed or not
@@ -98,10 +119,14 @@ public class ToggleMod extends BaseMod {
     return super.getDebugDisplayText();
   }
 
+  @Override
+  public boolean isInfoDisplayElement() {
+	return false;
+  }
+  
   /**
    * Check if the mod is currently shown
    */
-  
   @Override
   public boolean isHidden() {
     return false;
@@ -111,7 +136,7 @@ public class ToggleMod extends BaseMod {
   public boolean notInList() {
 	return nolist.get();
   }
-
+  
   /**
    * Check if the mod is currently enabled
    */

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -35,14 +35,6 @@ public class ToggleMod extends BaseMod {
             .name("hidden")
             .description("Hides the mod from modlist")
             .defaultTo(defaultValue)
-            .changed(
-                cb -> {
-                  if (cb.getTo()) {
-                    start();
-                  } else {
-                    stop();
-                  }
-                })
             .build();
   }
   

--- a/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
+++ b/src/main/java/com/matt/forgehax/util/mod/ToggleMod.java
@@ -88,27 +88,6 @@ public class ToggleMod extends BaseMod {
     nolist.set(false);
   }
   
-  /**
-   * Toggle mod to be displayed or not
-   */
-  public final void display() {
-    if (notInList()) {
-      hide();
-    } else {
-      show();
-    }
-  }
-  
-  @Override
-  public void hide() {
-    nolist.set(true);
-  }
-  
-  @Override
-  public void show() {
-    nolist.set(false);
-  }
-  
   @Override
   protected StubBuilder buildStubCommand(StubBuilder builder) {
     return builder.kpressed(this::onBindPressed).kdown(this::onBindKeyDown).bind();


### PR DESCRIPTION
I increased version number to `2.9.1`
I reordered the click GUI, now most mods aren't under `Player` anymore.
I added the possibility to hide certain mods from the ModList (not setting `hidden`!)
I added 2 modes to ElytraFlight : a basic `control` mode which won't keep altitude and `packet` mode (with infinite durability and nice speeds, but patched on 2b).
AntiBats is not AntiUselessMobs and can hide squids too.
ThisModIsDedicatedToUfoCrossing has now a name which won't take up all screen.
MatrixNotifications can now hook to Discord Webhooks (set `provider`) and can relay in-game chat completely.
I added a configurable watermark mod which by default shows ForgeHax version.
I added a configurable ChatWatermark (some people actually use it wtf?????)


OverFloyd added InfoDisplay with some system info (FPS, ping, Saturation...) and I'm PRing his changes too!