### PR TITLE
feature/AccountManager

### DIFF
--- a/src/main/java/com/matt/forgehax/asm/reflection/FastReflection.java
+++ b/src/main/java/com/matt/forgehax/asm/reflection/FastReflection.java
@@ -178,7 +178,17 @@ public interface FastReflection extends ASMCommon {
         .setName("entityID")
         .autoAssign()
         .asField();
-    
+
+    /**
+     * Session
+     */
+    FastField<Session> Minecraft_session =
+        FastTypeBuilder.create()
+            .setInsideClass(Minecraft.class)
+            .setName("session")
+            .autoAssign()
+            .asField();
+
     /**
      * SPacketPlayerPosLook
      */

--- a/src/main/java/com/matt/forgehax/mods/commands/HelpCommand.java
+++ b/src/main/java/com/matt/forgehax/mods/commands/HelpCommand.java
@@ -5,6 +5,8 @@ import static com.matt.forgehax.Helper.getLocalPlayer;
 import static com.matt.forgehax.Helper.getModManager;
 
 import com.google.common.util.concurrent.FutureCallback;
+import com.matt.forgehax.asm.reflection.FastReflection;
+import com.matt.forgehax.mods.managers.AccountManager;
 import com.matt.forgehax.util.command.Command;
 import com.matt.forgehax.util.command.CommandBuilders;
 import com.matt.forgehax.util.console.ConsoleIO;
@@ -23,11 +25,11 @@ import joptsimple.internal.Strings;
  */
 @RegisterMod
 public class HelpCommand extends CommandMod {
-  
+
   public HelpCommand() {
     super("HelpCommand");
   }
-  
+
   @RegisterCommand
   public Command save(CommandBuilders builder) {
     return builder
@@ -37,7 +39,7 @@ public class HelpCommand extends CommandMod {
       .processor(data -> getGlobalCommand().serializeAll())
       .build();
   }
-  
+
   @RegisterCommand
   public Command help(CommandBuilders builder) {
     return builder
@@ -56,7 +58,7 @@ public class HelpCommand extends CommandMod {
         })
       .build();
   }
-  
+
   @RegisterCommand
   public Command search(CommandBuilders builder) {
     return builder
@@ -98,7 +100,7 @@ public class HelpCommand extends CommandMod {
         })
       .build();
   }
-  
+
   @RegisterCommand
   public Command history(CommandBuilders builder) {
     return builder
@@ -137,7 +139,7 @@ public class HelpCommand extends CommandMod {
                 }
                 ConsoleIO.setIndents(previousIndents);
               }
-              
+
               @Override
               public void onFailure(Throwable t) {
               }
@@ -147,7 +149,7 @@ public class HelpCommand extends CommandMod {
         })
       .build();
   }
-  
+
   @RegisterCommand
   public Command loaded(CommandBuilders builder) {
     return builder
@@ -173,7 +175,7 @@ public class HelpCommand extends CommandMod {
         })
       .build();
   }
-  
+
   @RegisterCommand
   public Command online(CommandBuilders builder) {
     return builder
@@ -183,11 +185,11 @@ public class HelpCommand extends CommandMod {
       .processor(
         data -> {
           List<PlayerInfo> players = PlayerInfoHelper.getOnlinePlayers();
-          
+
           if (players.size() > 0) {
             final String match =
               data.getArgumentCount() > 0 ? data.getArgumentAsString(0).toLowerCase() : "";
-            
+
             StringBuilder str = new StringBuilder();
             str.append(players.size());
             if (match.isEmpty()) {
@@ -212,7 +214,7 @@ public class HelpCommand extends CommandMod {
         })
       .build();
   }
-  
+
   @RegisterCommand
   public Command respawn(CommandBuilders builder) {
     return builder
@@ -230,7 +232,7 @@ public class HelpCommand extends CommandMod {
         })
       .build();
   }
-  
+
   @RegisterCommand
   public Command clearChat(CommandBuilders builders) {
     return builders
@@ -242,5 +244,21 @@ public class HelpCommand extends CommandMod {
         () -> MC.ingameGUI.getChatGUI().clearChatMessages(d.hasOption("all")))
       )
       .build();
+  }
+
+  /**
+   * Added by OverFloyd on july 12, 2020
+   */
+  @RegisterCommand
+  public Command reauth(CommandBuilders builders) {
+    return builders
+        .newCommandBuilder()
+        .name("reauth")
+        .description("Reauths with the account you're currently using.")
+        .processor(data -> {
+          final String alias = FastReflection.Fields.Minecraft_session.get(MC).getUsername();
+          AccountManager.INSTANCE.login(alias);
+        })
+        .build();
   }
 }

--- a/src/main/java/com/matt/forgehax/mods/managers/AccountManager.java
+++ b/src/main/java/com/matt/forgehax/mods/managers/AccountManager.java
@@ -1,0 +1,515 @@
+package com.matt.forgehax.mods.managers;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.matt.forgehax.asm.reflection.FastReflection;
+import com.matt.forgehax.util.AuthHelper;
+import com.matt.forgehax.util.FileManager;
+import com.matt.forgehax.util.SimpleTimer;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.ServiceMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.util.Session;
+import net.minecraft.util.text.TextFormatting;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.matt.forgehax.Helper.*;
+import static com.matt.forgehax.util.AuthHelper.*;
+
+/**
+ * Added by OverFloyd, july 2020
+ * Additional credits to Tonio_Cartonio
+ */
+@RegisterMod
+public class AccountManager extends ServiceMod {
+
+  public final Setting<SecretKeyOptions> mode =
+    getCommandStub()
+      .builders()
+      .<SecretKeyOptions>newSettingEnumBuilder()
+      .name("pw-mode")
+      .description("Master password (safer) or default (secretKey generated automatically and saved on disk).")
+      .defaultTo(SecretKeyOptions.MASTERPASSWORD)
+      .build();
+
+  public final Setting<Integer> mpwDelay =
+    getCommandStub()
+      .builders()
+      .<Integer>newSettingBuilder()
+      .name("delay")
+      .description("Delay in ms after which masterPassword is reset, \"0\" to disable.")
+      .defaultTo(120000) // 2 min
+      .min(0)
+      .build();
+
+  public enum SecretKeyOptions {
+    MASTERPASSWORD,
+    DEFAULT
+  }
+
+  public AccountManager() {
+    super("AccountManager");
+    INSTANCE = this;
+  }
+
+  private final AuthHelper auth = new AuthHelper();
+  private final Session originalSession = FastReflection.Fields.Minecraft_session.get(MC);
+  private final SimpleTimer mpwTimer = new SimpleTimer();
+  public static AccountManager INSTANCE;
+  public static char[] masterPassword;
+  public String logInResponse;
+
+  @Override
+  protected void onLoad() {
+    super.onLoad();
+    StringBuilder loginBuilder = new StringBuilder("Login with provided alias");
+    StringBuilder saveBuilder = new StringBuilder("For saving or editing an account, <alias> <email> <password>");
+
+    // TODO: make this happen on setting change/on printing somehow
+    if (mode.get() == SecretKeyOptions.MASTERPASSWORD && masterPassword == null) {
+      String append = TextFormatting.GOLD + " [requires master password first]";
+      loginBuilder.append(append);
+      saveBuilder.append(append);
+    }
+
+
+    // MASTER PASSWORD
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("master-password")
+      .description("Password to submit to allow credentials encryption/decryption.")
+      .processor(
+        data -> {
+          if (masterPassword == null) {
+            data.requiredArguments(1);
+            char[] candidatePassword = data.getArgumentAsString(0).toCharArray();
+
+            if (!checkForMpwFile() && !checkForAuthFile()) {
+              try {
+
+                // Saves .check file for masterPassword && .auth file if not present.
+                generateSecretKey();
+                saveEncryptCheck(candidatePassword);
+              } catch (IOException e) {
+                e.printStackTrace();
+              }
+            }
+
+            final File checkFile = new File(directory + File.separator + ".check");
+
+            try {
+              final FileReader fileReader = new FileReader(checkFile);
+              final JsonObject object = new JsonParser().parse(fileReader).getAsJsonObject();
+              fileReader.close();
+
+              String check = decrypt(object.get("mpwCheckField").getAsString(),
+                object.get("ivField").getAsString(), Arrays.toString(candidatePassword), getSalt());
+
+              if (check != null && check.equals("Correct!")) {
+                masterPassword = candidatePassword;
+                mpwTimer.start();
+                printInform("Master password has been set correctly.");
+              } else printError("Submitted master password is incorrect.");
+
+            } catch (IOException e) {
+              e.printStackTrace();
+            }
+          } else printError("Master password has already been defined.");
+        })
+      .build();
+
+
+    // LOGIN
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("login")
+      .description(loginBuilder.toString() + ".")
+      .processor(data -> {
+        data.requiredArguments(1);
+        final String alias = data.getArgumentAsString(0);
+
+        login(alias);
+      })
+      .build();
+
+
+    // SAVE
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("save")
+      .description(saveBuilder.toString() + ".")
+      .processor(
+        data -> {
+          data.requiredArguments(3);
+          final String alias = data.getArgumentAsString(0);
+          final String email = data.getArgumentAsString(1);
+          final String password = data.getArgumentAsString(2);
+          final String newIV = generateIV();
+
+          if (alias.startsWith(".")) {
+            printWarning("Invalid alias.");
+            return;
+          }
+
+          // Checks if .auth is present, if not it generates a new one
+          if (!checkForAuthFile()) {
+            printError("Auth file is missing, regenerating keys...");
+            printInform("If you're saving an account for the first time, it's all good.");
+            generateSecretKey();
+          }
+
+          // Check if the delay for timer has elapsed
+          checkTimer();
+
+          final File account = new File(directory.getAbsolutePath() + "/" + alias + ".json");
+          final JsonObject object = new JsonObject();
+
+          // Creates new file if it doesn't exist
+          if (!account.exists()) {
+            try {
+              object.addProperty("alias", (String) data.arguments().get(0));
+              object.addProperty("iv", newIV);
+              object.addProperty("credentials", encrypt(createAccount(email, password), newIV, getSecretKey(), getSalt()));
+
+              if (directory.exists()) {
+                if (getSecretKey() != null) {
+                  FileManager.save(account, object);
+                  printInform("Saved new account: %s.", alias);
+                } else printError("Master password or default password is blank.");
+              } else printError("Failed to locate SavedAccounts folder.");
+
+            } catch (IOException e) {
+              e.printStackTrace();
+              printError("Failed to locate .auth file.");
+              printInform("The exception is: %s.", e.getMessage());
+            }
+          } else {
+            try {
+              final FileReader fileReader = new FileReader(account);
+              final JsonObject objectReader = new JsonParser().parse(fileReader).getAsJsonObject();
+              fileReader.close();
+
+              String credentials = decrypt(objectReader.get("credentials").getAsString(), getIV(alias), getSecretKey(), getSalt());
+              getLog().info("Credentials decrypted (for credentials comparison).");
+
+              // Gets credentials
+              if (credentials != null) {
+                final JsonObject objectCred = new JsonParser().parse(credentials).getAsJsonObject();
+
+                String emailIn = objectCred.get("email").getAsString();
+                String passwordIn = objectCred.get("password").getAsString();
+
+                // Compare submitted data with already existing data
+                if (email.equalsIgnoreCase(emailIn) && password.equals(passwordIn)) {
+                  printMessage("Credentials for \"%s\" didn't change.", alias);
+                } else {
+                  if (email.equalsIgnoreCase(emailIn)) {
+                    getLog().info("Email for \"" + alias + "\" didn't change.");
+                  } else if (password.equals(passwordIn)) {
+                    getLog().info("Password for \"" + alias + "\" didn't change.");
+                  }
+
+                  // Saves the data that did change
+                  object.addProperty("alias", (String) data.arguments().get(0));
+                  object.addProperty("iv", getIV(alias));
+                  object.addProperty("credentials", encrypt(createAccount(email, password), getIV(alias), getSecretKey(), getSalt()));
+                  getLog().info("Credentials encrypted (account was edited).");
+
+                  if (directory.exists()) {
+                    if (getSecretKey() != null) {
+                      FileManager.save(account, object);
+                      printInform("Successfully edited account \"%s\".", alias);
+                    } else printError("Master password or default password is blank.");
+                  } else printError("Failed to locate SavedAccounts folder.");
+                }
+              } else printError("Failed to decrypt credentials.");
+            } catch (IOException e) {
+              e.printStackTrace();
+              printError("Failed to load \"%s\".json file.", alias);
+              printInform("The exception is: %s.", e.getMessage());
+            }
+          }
+        })
+      .build();
+
+
+    // DELETE
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("delete")
+      .description("<alias> for a single account, \"*\" for all files.")
+      .processor(
+        data -> {
+          data.requiredArguments(1);
+          String alias = data.getArgumentAsString(0);
+          final File account = new File(directory + File.separator + alias + ".json");
+
+          if (alias.equals("*")) {
+            for (final File fileEntry : Objects.requireNonNull(directory.listFiles())) {
+              if (!fileEntry.isDirectory()) {
+                fileEntry.getAbsoluteFile().delete();
+                getLog().info("Deleted " + fileEntry.getName());
+              }
+            }
+
+            printInform("Deleted all saved accounts.");
+          } else if (account.exists()) {
+            account.delete();
+            printInform("Deleted account \"%s\".", alias);
+          } else printError("Couldn't find \"%s\".", alias);
+        })
+      .build();
+
+
+    // RESTORE
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("restore")
+      .description("Switch back to the original session.")
+      .processor(
+        data -> {
+          String getSessionUsername = FastReflection.Fields.Minecraft_session.get(MC).getUsername();
+
+          if (!getSessionUsername.equals(originalSession.getUsername())) {
+            auth.setSession(originalSession);
+            printInform("Successfully switched to the original session.");
+          } else printMessage("Session didn't change.");
+        })
+      .build();
+
+
+    // LIST
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("list")
+      .description("Lists all saved accounts.")
+      .processor(
+        data -> {
+          if (directory.exists()) {
+
+            if (Objects.requireNonNull(new File(String.valueOf(directory)).listFiles()).length < 3) {
+              printMessage("No accounts found.");
+            } else {
+
+              // Accounts found
+              printMessage("Saved accounts (by alias):");
+
+              for (final File fileEntry : Objects.requireNonNull(directory.listFiles())) {
+                if (!fileEntry.isDirectory() && fileEntry.getName().endsWith(".json")) {
+                  data.write(fileEntry.getName().replace(".json", ""));
+                }
+              }
+            }
+          } else printError("Failed to locate SavedAccounts folder.");
+        })
+      .build();
+
+
+    // COUNT
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("count")
+      .description("Prints the number of all saved accounts.")
+      .processor(
+        data -> {
+          if (directory.exists()) {
+            int count = 0;
+
+            for (final File fileEntry : Objects.requireNonNull(directory.listFiles())) {
+              if (!fileEntry.isDirectory() && fileEntry.getName().endsWith(".json")) {
+                count++;
+              }
+            }
+
+            if (count != 0) {
+              printInform("Number of saved accounts: %s.", count);
+            } else printMessage("No accounts found.");
+          } else printError("Failed to locate SavedAccounts folder.");
+        })
+      .build();
+
+
+    // WHO AM I
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("whoami")
+      .description("Prints the name of the account you're currently using.")
+      .processor(data -> printInform("Currently logged in as: %s.", FastReflection.Fields.Minecraft_session.get(MC).getUsername()))
+      .build();
+
+
+    // RESET KEYS
+    getCommandStub()
+      .builders()
+      .newCommandBuilder()
+      .name("regen-key")
+      .description("Resets secretKey & salt (useful for debugging).")
+      .processor(
+        data -> {
+          if (directory.exists()) {
+
+            // Checks for auth files
+            if (checkForAuthFile()) {
+              printInform(".auth file is already present.");
+              return;
+            }
+
+            generateSecretKey();
+            printInform("Successfully regenerated .auth file.");
+          } else printError("Failed to locate SavedAccounts folder.");
+        })
+      .build();
+  }
+
+  public boolean login(String alias) {
+    // Checks for auth files
+    if (!checkForAuthFile()) {
+      logInResponse = "Failed to locate .auth file.";
+      printError(logInResponse);
+      return false;
+    }
+
+    final File account = new File(directory + File.separator + alias + ".json");
+
+    if (account.exists()) {
+      try {
+        final FileReader fileReader = new FileReader(account);
+        final JsonObject object = new JsonParser().parse(fileReader).getAsJsonObject();
+        fileReader.close();
+
+        // Check if the delay set has elapsed
+        checkTimer();
+
+        String name = object.get("alias").getAsString();
+        String credentials = decrypt(object.get("credentials").getAsString(), getIV(name), getSecretKey(), getSalt());
+        getLog().info("Credentials decrypted (for login or reauth).");
+
+        // Gets credentials
+        if (credentials != null) {
+          final JsonObject objectCred = new JsonParser().parse(credentials).getAsJsonObject();
+
+          String email = objectCred.get("email").getAsString();
+          String password = objectCred.get("password").getAsString();
+
+          // Sets new session with the new credentials
+          try {
+            auth.newLogin(email, password);
+            logInResponse = String.format("Successfully logged in as \"%s\".", FastReflection.Fields.Minecraft_session.get(MC).getUsername());
+            printInform(logInResponse);
+          } catch (Exception e) {
+            logInResponse = String.format("Could not login as \"%s\". The exception is: %s.", name, e.getMessage());
+            printError(logInResponse);
+            return false;
+          }
+        } else {
+          logInResponse = "Failed to decrypt credentials.";
+          printError(logInResponse);
+          return false;
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+        logInResponse = String.format("Failed to load \"%s.json\" file, with exception %s", alias, e.getMessage());
+        printError(logInResponse);
+        return false;
+      }
+    } else {
+      logInResponse = String.format("Couldn't find data for \"%s\".", alias);
+      printError(logInResponse);
+      return false;
+    }
+
+    return true;
+  }
+
+  public void checkTimer() {
+    if (mpwTimer.hasTimeElapsed(mpwDelay.get()) && mpwDelay.get() != 0) {
+      masterPassword = null;
+    }
+  }
+
+  public static boolean checkForAuthFile() {
+    boolean isFilePresent = false;
+
+    if (directory.exists()) {
+      for (final File fileEntry : Objects.requireNonNull(directory.listFiles())) {
+        if (!fileEntry.isDirectory() && fileEntry.getName().equals(".auth")) {
+          isFilePresent = true;
+        }
+      }
+    } else printError("Failed to locate SavedAccounts folder.");
+
+    return isFilePresent;
+  }
+
+  public static boolean checkForMpwFile() {
+    boolean isFilePresent = false;
+
+    if (directory.exists()) {
+      for (final File fileEntry : Objects.requireNonNull(directory.listFiles())) {
+        if (!fileEntry.isDirectory() && fileEntry.getName().equals(".check")) {
+          isFilePresent = true;
+        }
+      }
+    } else printError("Failed to locate SavedAccounts folder.");
+
+    return isFilePresent;
+  }
+
+  // IV unique per account
+  public static String generateIV() {
+    return RandomStringUtils.random(16, 0, 0, true, true, null, new SecureRandom());
+  }
+
+  public static void generateSecretKey() {
+    final File authFile = new File(directory + File.separator + ".auth");
+    final JsonObject authObject = new JsonObject();
+
+    String secretKey = RandomStringUtils.random(64, 0, 0, true, true, null, new SecureRandom());
+    String keySalt = RandomStringUtils.random(64, 0, 0, true, true, null, new SecureRandom());
+
+    authObject.addProperty("keyField", secretKey);
+    authObject.addProperty("saltField", keySalt);
+
+    FileManager.save(authFile, authObject);
+    getLog().info("Saved " + authFile.getName() + " file.");
+  }
+
+  public static void saveEncryptCheck(char[] masterPw) throws IOException {
+    final File checkFile = new File(directory + File.separator + ".check");
+    final JsonObject checkObject = new JsonObject();
+    String mpwIV = generateIV();
+    String mpwCheck = encrypt("Correct!", mpwIV, Arrays.toString(masterPw), getSalt());
+
+    checkObject.addProperty("ivField", mpwIV);
+    checkObject.addProperty("mpwCheckField", mpwCheck);
+
+    FileManager.save(checkFile, checkObject);
+    getLog().info("Saved " + checkFile.getName() + " file.");
+  }
+
+  // Serialized json with email & password
+  public String createAccount(String email, String password) {
+    final JsonObject object = new JsonObject();
+    object.addProperty("email", email);
+    object.addProperty("password", password);
+
+    Gson gson = new Gson();
+    return gson.toJson(object);
+  }
+}

--- a/src/main/java/com/matt/forgehax/mods/services/ReauthService.java
+++ b/src/main/java/com/matt/forgehax/mods/services/ReauthService.java
@@ -1,0 +1,102 @@
+package com.matt.forgehax.mods.services;
+
+import com.matt.forgehax.asm.reflection.FastReflection;
+import com.matt.forgehax.mods.managers.AccountManager;
+import com.matt.forgehax.util.SimpleTimer;
+import com.matt.forgehax.util.command.Setting;
+import com.matt.forgehax.util.mod.Category;
+import com.matt.forgehax.util.mod.ToggleMod;
+import com.matt.forgehax.util.mod.loader.RegisterMod;
+import net.minecraft.client.gui.GuiDisconnected;
+import net.minecraftforge.client.event.GuiOpenEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import static com.matt.forgehax.Helper.getLog;
+
+/**
+ * Added by OverFloyd & TotalDarkness
+ * July 2020
+ */
+@RegisterMod
+public class ReauthService extends ToggleMod {
+
+  private final Setting<String> discordWebhookUrl =
+    getCommandStub()
+      .builders()
+      .<String>newSettingBuilder()
+      .name("webhook-url")
+      .description("The discord web-hook link to send notifications.")
+      .defaultTo("")
+      .build();
+
+  private final Setting<Boolean> sendDiscordMsgs =
+    getCommandStub()
+      .builders()
+      .<Boolean>newSettingBuilder()
+      .name("send-discord-msgs")
+      .description("Send discord notifications.")
+      .defaultTo(false)
+      .build();
+
+  public final Setting<Integer> delay =
+    getCommandStub()
+      .builders()
+      .<Integer>newSettingBuilder()
+      .name("delay")
+      .description("Delay in ms between each auth attempt.")
+      .defaultTo(240000) // 4 minutes
+      .build();
+
+  public ReauthService() {
+    super(Category.MISC, "ReauthService", false, "Reauths on invalid session.");
+  }
+
+  private final SimpleTimer timer = new SimpleTimer();
+  boolean isSessionValid;
+  int counter;
+
+  @SubscribeEvent
+  public void guiOpen(final GuiOpenEvent event) {
+    if (event.getGui() instanceof GuiDisconnected) {
+      final String disconnectMsg = getDisconnectedMsg((GuiDisconnected) event.getGui());
+
+      if (disconnectMsg.contains("Failed to login")) {
+
+        // Anti auth-spam if there's too many failed attempts
+        if (!isSessionValid && !timer.hasTimeElapsed(delay.get())) {
+          int countdown = (int) (delay.get() - timer.getTimeElapsed());
+
+          getLog().info("Too many failed attempts, wait " + countdown + " ms.");
+          return;
+        }
+
+        final String alias = FastReflection.Fields.Minecraft_session.get(MC).getUsername();
+
+        if (AccountManager.INSTANCE.login(alias)) {
+          isSessionValid = true;
+        } else {
+          isSessionValid = false;
+          counter++;
+        }
+
+        // Start timer to prevent being auth-blocked by moejang
+        if (counter > 2) {
+          timer.start();
+          counter = 0; // Reset counter, else it keeps going after the delay has elapsed
+        }
+      }
+    }
+  }
+
+  private String getDisconnectedMsg(GuiDisconnected disconnected) {
+    String message;
+
+    try {
+      message = FastReflection.Fields.GuiDisconnected_message.get(disconnected).getUnformattedText();
+    } catch (Exception e) {
+      message = e.getMessage(); // do this cause lazy
+    }
+
+    return message;
+  }
+}

--- a/src/main/java/com/matt/forgehax/util/AuthHelper.java
+++ b/src/main/java/com/matt/forgehax/util/AuthHelper.java
@@ -1,0 +1,145 @@
+package com.matt.forgehax.util;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.matt.forgehax.asm.reflection.FastReflection;
+import com.matt.forgehax.mods.managers.AccountManager;
+import com.mojang.authlib.Agent;
+import com.mojang.authlib.exceptions.AuthenticationException;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+import com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication;
+import com.mojang.util.UUIDTypeAdapter;
+import net.minecraft.util.Session;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.spec.KeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.UUID;
+
+import static com.matt.forgehax.Globals.MC;
+import static com.matt.forgehax.Helper.getLog;
+import static com.matt.forgehax.mods.managers.AccountManager.masterPassword;
+
+/**
+ * Added by OverFloyd, july 2020
+ */
+public final class AuthHelper extends YggdrasilUserAuthentication {
+
+  private final YggdrasilAuthenticationService authService;
+  public static final File directory = FileManager.getInstance().getMkBaseDirectory("/config/SavedAccounts").toFile();
+
+  public AuthHelper() {
+    super(new YggdrasilAuthenticationService(MC.getProxy(), null), Agent.MINECRAFT);
+    authService = new YggdrasilAuthenticationService(MC.getProxy(), UUID.randomUUID().toString());
+  }
+
+  @Override
+  public YggdrasilAuthenticationService getAuthenticationService() {
+    return authService;
+  }
+
+  public void setSession(Session s) {
+    FastReflection.Fields.Minecraft_session.set(MC, s);
+  }
+
+  public void newLogin(String login, String password) throws AuthenticationException {
+    setUsername(login);
+    setPassword(password);
+
+    // For new client token.
+    logInWithPassword();
+    Session newSession = new Session(getSelectedProfile().getName(),
+      UUIDTypeAdapter.fromUUID(getSelectedProfile().getId()), getAuthenticatedToken(), getUserType().getName());
+
+    newSession.setProperties(getUserProperties());
+    logOut();
+    setSession(newSession);
+  }
+
+  public static String encrypt(String encryptString, String iv, String key, String keySalt) {
+    try {
+      SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+      KeySpec spec = new PBEKeySpec(key.toCharArray(), keySalt.getBytes(), 65536, 128);
+      SecretKey tmp = factory.generateSecret(spec);
+      SecretKeySpec secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");
+
+      Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes());
+      cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivSpec);
+
+      return Base64.getEncoder().encodeToString(cipher.doFinal(encryptString.getBytes(StandardCharsets.UTF_8)));
+    } catch (Exception e) {
+      e.printStackTrace();
+      getLog().error("Encryption error: " + e.toString());
+    }
+
+    return null;
+  }
+
+  public static String decrypt(String decryptString, String iv, String key, String keySalt) {
+    try {
+      SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1");
+      KeySpec spec = new PBEKeySpec(key.toCharArray(), keySalt.getBytes(), 65536, 128);
+      SecretKey tmp = factory.generateSecret(spec);
+      SecretKeySpec secretKey = new SecretKeySpec(tmp.getEncoded(), "AES");
+
+      Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+      IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes());
+      cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec);
+
+      return new String(cipher.doFinal(Base64.getDecoder().decode(decryptString.getBytes(StandardCharsets.UTF_8))));
+    } catch (Exception e) {
+      e.printStackTrace();
+      getLog().error("Decryption error: " + e.toString());
+    }
+
+    return null;
+  }
+
+  // Returns the secret key
+  // SecretKey in .auth if mode is DEFAULT, master password if mode is MASTERPASSWORD
+  public static String getSecretKey() throws IOException {
+    if (AccountManager.INSTANCE.mode.get() == AccountManager.SecretKeyOptions.DEFAULT) {
+      final File secretKeyFile = new File(directory + File.separator + ".auth");
+      final FileReader fileReader = new FileReader(secretKeyFile);
+      final JsonObject object = new JsonParser().parse(fileReader).getAsJsonObject();
+      fileReader.close();
+
+      return object.get("keyField").getAsString();
+    } else if (masterPassword == null) {
+      getLog().error("getSecretKey() returned null.");
+      return null;
+    } else return Arrays.toString(masterPassword);
+  }
+
+  // Gets the salt from file
+  public static String getSalt() throws IOException {
+    final File saltFile = new File(directory + File.separator + ".auth");
+
+    final FileReader fileReader = new FileReader(saltFile);
+    final JsonObject object = new JsonParser().parse(fileReader).getAsJsonObject();
+    fileReader.close();
+
+    return object.get("saltField").getAsString();
+  }
+
+  public static String getIV(String alias) throws IOException {
+    final File ivFile = new File(directory + File.separator + alias + ".json");
+
+    final FileReader fileReader = new FileReader(ivFile);
+    final JsonObject object = new JsonParser().parse(fileReader).getAsJsonObject();
+    fileReader.close();
+
+    return object.get("iv").getAsString();
+  }
+}

--- a/src/main/java/com/matt/forgehax/util/FileManager.java
+++ b/src/main/java/com/matt/forgehax/util/FileManager.java
@@ -1,6 +1,10 @@
 package com.matt.forgehax.util;
 
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,6 +12,9 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static com.matt.forgehax.Helper.printError;
+import static com.matt.forgehax.Helper.printInform;
 
 /**
  * Created on 5/30/2017 by fr1kin
@@ -97,12 +104,23 @@ public class FileManager {
   }
   
   public Path getMkBaseDirectory(String... names) {
-    return getMkDirectory(
-        getBasePath(), expandPaths(names).collect(Collectors.joining(File.separator)));
+    return getMkDirectory(getBasePath(), expandPaths(names).collect(Collectors.joining(File.separator)));
   }
   
   public Path getMkConfigDirectory(String... names) {
     return getMkDirectory(
         getConfig(), expandPaths(names).collect(Collectors.joining(File.separator)));
+  }
+
+  public static void save(final File file, final JsonObject jsonObject) {
+    try {
+      FileWriter fileWriter = new FileWriter(file);
+      fileWriter.write(new GsonBuilder().setPrettyPrinting().create().toJson(jsonObject));
+      fileWriter.close();
+    } catch (IOException e) {
+      e.printStackTrace();
+      printError("Failed to save the submitted data.");
+      printInform("The exception is: " + e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
New manager that allows you to manage and use accounts from Command Input.
Commands:
* pw-mode: default (secretKey saved on disk) or master password (secretKey is never stored);
* delay: delay in seconds after which master password is reset, "0" to disable
* master-password;
* save - For saving or editing an already existing account, <alias> <email> <password>;
* login - Login with provided alias;
* delete - Deletes a saved account (requires the alias), "*" for all accounts and .auth for deleting just the auth file;
* restore - Switch back to the original session;
* list - Lists all saved accounts;
* count - Prints the number of all saved accounts;
* reset-auth-data - resets secretkey & salts if needed;
* whoami: return the name for the account you're currently using.

Accounts are stored in a separate folder (SavedAccounts) and they have their dedicated json file. Email and password are encrypted, secretKey is your HWID and salts are stored in a separate file (".auth" aka just a fake json).

New helper: AuthHelper
* Used to login with a chosen account.
* Contains the methods for encrypting & decrypting.

New service mode: reauth (also as a command in HelpCommand)
* reauth with the account you're currently using (needs AccountManager to be set up).